### PR TITLE
OORT-278 : Change permission check for resources

### DIFF
--- a/src/models/form.ts
+++ b/src/models/form.ts
@@ -41,29 +41,20 @@ const formSchema = new Schema({
     ],
     canSeeRecords: [
       {
-        role: {
-          type: mongoose.Schema.Types.ObjectId,
-          ref: 'Role',
-        },
-        access: mongoose.Schema.Types.Mixed,
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Role',
       },
     ],
     canUpdateRecords: [
       {
-        role: {
-          type: mongoose.Schema.Types.ObjectId,
-          ref: 'Role',
-        },
-        access: mongoose.Schema.Types.Mixed,
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Role',
       },
     ],
     canDeleteRecords: [
       {
-        role: {
-          type: mongoose.Schema.Types.ObjectId,
-          ref: 'Role',
-        },
-        access: mongoose.Schema.Types.Mixed,
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Role',
       },
     ],
     recordsUnicity: [

--- a/src/schema/query/resource.ts
+++ b/src/schema/query/resource.ts
@@ -1,7 +1,8 @@
 import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { ResourceType } from '../types';
-import { Resource } from '../../models';
+import { Form, Resource } from '../../models';
 import { AppAbility } from '../../security/defineAbilityFor';
+import mongoose from 'mongoose';
 
 export default {
   /*  Returns resource from id if available for the logged user.
@@ -13,19 +14,28 @@ export default {
   },
   async resolve(parent, args, context) {
     // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('errors.userNotLogged'));
-    }
-
     const ability: AppAbility = context.user.ability;
-    const filters = Resource.accessibleBy(ability, 'read')
-      .where({ _id: args.id })
-      .getFilter();
-    const resource = await Resource.findOne(filters);
-    if (!resource) {
+    const filterReturn = Resource.where({ _id: args.id }).getFilter();
+    const resourceToReturn = await Resource.findOne(filterReturn);
+    let canRead = false;
+    //Check global resource permission
+    if (ability.can('read', resourceToReturn)) {
+      canRead = true;
+    } else {
+      //Check per records permission
+      const form = await Form.findOne({ resource: resourceToReturn.id });
+      const roles = context.user.roles.map((x) =>
+        mongoose.Types.ObjectId(x._id)
+      );
+      canRead =
+        form.permissions.canSeeRecords.length > 0
+          ? form.permissions.canSeeRecords.some((x) => roles.includes(x))
+          : false;
+    }
+    if (!canRead) {
       throw new GraphQLError(context.i18next.t('errors.permissionNotGranted'));
     }
-    return resource;
+    //Return resource if user can see it
+    return resourceToReturn;
   },
 };


### PR DESCRIPTION
# Description

Changes the way we handle permissions for the resources (used when displaying a grid).
First using the ability object we check the global and local permissions to see the resource (either the role of the user has the global can_see_resources attribute or the canSee attribute is defined locally for this resource and this role). Then we see if the form from which the resource comes from has the canSeeRecords attribute defined for this role.

I changed the way the canSeeRecords, canCreateRecords and canDeleteRecords were handled to make them more coherent with the other permissions and easier to manipulate.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


- [x] Tested by using different users with different roles and displaying grids where the users had different permissions defined in every layer (global, local or per records)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have included screenshots describing my changes if relevant
