### PR TITLE
OORT-309 - allows null in group aggregation

### DIFF
--- a/src/utils/aggregation/buildPipeline.ts
+++ b/src/utils/aggregation/buildPipeline.ts
@@ -64,11 +64,11 @@ const buildPipeline = (
             const fieldArray = x.field.split('.');
             const parent = fieldArray.shift();
             pipeline.push({
-              $unwind: `$${parent}`,
+              $unwind: { path: `$${parent}`, preserveNullAndEmptyArrays: true },
             });
           }
           pipeline.push({
-            $unwind: `$${x.field}`,
+            $unwind: { path: `$${x.field}`, preserveNullAndEmptyArrays: true },
           });
           if (x.expression && x.expression.operator) {
             pipeline.push({


### PR DESCRIPTION
# Description

This PR changes the grouping pipeline to allow null values to be grouped

## Type of change

Please delete options that are not relevant.
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

By creating a grouping step in the aggregation of a chart for a field that has null values.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have put JSDoc comment in all required places
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have included screenshots describing my changes if relevant
