### PR TITLE
Feat 1.3.0/oort 472 refactor main query to re use it for related records

### DIFF
--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -320,7 +320,7 @@ export const getEntityResolver = (
                   mongooseFilter[`data.${x.name}`] = entity.id.toString();
                   const filters = { $and: [mongooseFilter, userFilter] };
 
-                  return await Record.aggregate([
+                  return Record.aggregate([
                     ...linkedReferenceDataAggregation,
                     ...linkedRecordsAggregation,
                     ...createdByLookup,

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -3,7 +3,6 @@ import { isRelationshipField } from '../../introspection/isRelationshipField';
 import { Form, Record, ReferenceData, User, Version } from '../../../../models';
 import getReversedFields from '../../introspection/getReversedFields';
 import getFilter, { extractFilterFields } from '../Query/getFilter';
-import getSortField from '../Query/getSortField';
 import { defaultRecordFieldsFlat } from '../../../../const/defaultRecordFields';
 import extendAbilityForRecords from '../../../../security/extendAbilityForRecords';
 import { GraphQLID, GraphQLList } from 'graphql';
@@ -21,7 +20,6 @@ import {
 import getUserFilter from '../Query/getUserFilter';
 import { logger } from '../../../../services/logger.service';
 import getSortAggregation from '../Query/getSortAggregation';
-import buildReferenceDataAggregation from '../../../aggregation/buildReferenceDataAggregation';
 
 /** Default number for items to get */
 const DEFAULT_FIRST = 25;

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -307,7 +307,11 @@ export const getEntityResolver = (
                   // Get reference aggregation query
                   const relatedFields = data[entityName];
                   const linkedReferenceDataAggregation: any =
-                    await getReferenceFilter(usedFields,relatedFields,context);
+                    await getReferenceFilter(
+                      usedFields,
+                      relatedFields,
+                      context
+                    );
 
                   Object.assign(
                     mongooseFilter,

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -16,6 +16,7 @@ import {
   formLookup,
   getResourcesFilter,
   getReferenceFilter,
+  getUserPermissionFilter,
 } from '../Query/getLookup';
 import getUserFilter from '../Query/getUserFilter';
 import { logger } from '../../../../services/logger.service';
@@ -42,6 +43,8 @@ export const getEntityResolver = (
   referenceDatas: ReferenceData[]
 ) => {
   const fields = getFields(data[name]);
+
+  console.log('id =======>>>> ', id);
 
   const entityFields = Object.keys(fields);
 
@@ -145,7 +148,14 @@ export const getEntityResolver = (
                   { archived: { $ne: true } }
                 );
 
-                const filters = { $and: [mongooseFilter, userFilter] };
+                const permissionFilters = await getUserPermissionFilter(
+                  id,
+                  context
+                );
+
+                const filters = {
+                  $and: [mongooseFilter, permissionFilters, userFilter],
+                };
 
                 return await Record.aggregate([
                   ...linkedReferenceDataAggregation,
@@ -324,8 +334,15 @@ export const getEntityResolver = (
                     { archived: { $ne: true } }
                   );
 
+                  const permissionFilters = await getUserPermissionFilter(
+                    id,
+                    context
+                  );
+
                   mongooseFilter[`data.${x.name}`] = entity.id.toString();
-                  const filters = { $and: [mongooseFilter, userFilter] };
+                  const filters = {
+                    $and: [mongooseFilter, permissionFilters, userFilter],
+                  };
 
                   return Record.aggregate([
                     ...linkedReferenceDataAggregation,

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -99,17 +99,18 @@ export const getEntityResolver = (
               filter: {},
               first: DEFAULT_FIRST,
               skip: 0,
-            }
+            },
+            context
           ) => {
             // Filter from the query definition
             const mongooseFilter = args.filter
-              ? getFilter(args.filter, relatedFields)
+              ? getFilter(args.filter, relatedFields, context)
               : {};
 
             // Additional filter on user objects such as CreatedBy or LastUpdatedBy
             // Must be applied after users lookups in the aggregation
             const userFilter = args.filter
-              ? getUserFilter(args.filter, relatedFields, [])
+              ? getUserFilter(args.filter, relatedFields, context)
               : {};
 
             const usedFields = !!args.filter
@@ -128,7 +129,7 @@ export const getEntityResolver = (
 
             // Get reference aggregation query
             const linkedReferenceDataAggregation: any =
-              await getReferenceFilter(usedFields, relatedFields);
+              await getReferenceFilter(usedFields, relatedFields, context);
 
             try {
               let recordIds = get(
@@ -276,16 +277,17 @@ export const getEntityResolver = (
                 x.relatedName,
                 async (
                   entity,
-                  args = { sortField: null, sortOrder: 'asc', filter: {} }
+                  args = { sortField: null, sortOrder: 'asc', filter: {} },
+                  context
                 ) => {
                   const mongooseFilter = args.filter
-                    ? getFilter(args.filter, data[entityName])
+                    ? getFilter(args.filter, data[entityName], context)
                     : {};
 
                   // Additional filter on user objects such as CreatedBy or LastUpdatedBy
                   // Must be applied after users lookups in the aggregation
                   const userFilter = args.filter
-                    ? getUserFilter(args.filter, data[entityName], [])
+                    ? getUserFilter(args.filter, data[entityName], context)
                     : {};
 
                   const usedFields = !!args.filter
@@ -304,7 +306,7 @@ export const getEntityResolver = (
 
                   // Get reference aggregation query
                   const linkedReferenceDataAggregation: any =
-                    await getReferenceFilter(usedFields, data[entityName]);
+                    await getReferenceFilter(usedFields, data[entityName], context);
 
                   Object.assign(
                     mongooseFilter,

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -305,8 +305,9 @@ export const getEntityResolver = (
                   );
 
                   // Get reference aggregation query
+                  const relatedFields = data[entityName];
                   const linkedReferenceDataAggregation: any =
-                    await getReferenceFilter(usedFields, data[entityName], context);
+                    await getReferenceFilter(usedFields, relatedFields, context);
 
                   Object.assign(
                     mongooseFilter,

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -17,6 +17,7 @@ import getUserFilter from '../Query/getUserFilter';
 import { logger } from '../../../../services/logger.service';
 import getSortAggregation from '../Query/getSortAggregation';
 
+/** Default number for items to get */
 const DEFAULT_FIRST = 25;
 
 /**
@@ -172,7 +173,7 @@ export const getEntityResolver = (
 
                 const filters = { $and: [mongooseFilter, userFilter] };
 
-                return Record.aggregate([
+                return await Record.aggregate([
                   ...linkedRecordsAggregation,
                   ...createdByLookup,
                   ...formLookup,

--- a/src/utils/schema/resolvers/Entity/index.ts
+++ b/src/utils/schema/resolvers/Entity/index.ts
@@ -307,7 +307,7 @@ export const getEntityResolver = (
                   // Get reference aggregation query
                   const relatedFields = data[entityName];
                   const linkedReferenceDataAggregation: any =
-                    await getReferenceFilter(usedFields, relatedFields, context);
+                    await getReferenceFilter(usedFields,relatedFields,context);
 
                   Object.assign(
                     mongooseFilter,

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -20,7 +20,7 @@ import { getAccessibleFields } from '../../../../utils/form';
 const DEFAULT_FIRST = 25;
 
 /** Default aggregation common to all records to make lookups for default fields. */
-let defaultRecordAggregation: any = [
+const defaultRecordAggregation: any = [
   { $addFields: { id: { $toString: '$_id' } } },
   ...versionLookup,
   ...formLookup,

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -111,7 +111,10 @@ const buildMongoFilter = (
         if (
           filter.field.includes('.') &&
           !fields.find(
-            (x) => x.name === filter.field.split('.')[0] && x.referenceData.id
+            (x) =>
+              x.name === filter.field.split('.')[0] &&
+              x.referenceData &&
+              x.referenceData.id
           )
         ) {
           if (

--- a/src/utils/schema/resolvers/Query/getLookup.ts
+++ b/src/utils/schema/resolvers/Query/getLookup.ts
@@ -150,7 +150,7 @@ export const getResourcesFilter = (usedFields: any, relatedFields: any) => {
 export const getReferenceFilter = async (
   usedFields: any,
   relatedFields: any,
-  context
+  context:any
 ): Promise<any> => {
   const referenceDataFieldsToQuery = relatedFields.filter(
     (f) =>

--- a/src/utils/schema/resolvers/Query/getLookup.ts
+++ b/src/utils/schema/resolvers/Query/getLookup.ts
@@ -1,0 +1,79 @@
+export const createdByLookup = [
+  {
+    $lookup: {
+      from: 'users',
+      localField: 'createdBy.user',
+      foreignField: '_id',
+      as: '_createdBy.user',
+    },
+  },
+  {
+    $unwind: {
+      path: '$_createdBy.user',
+      preserveNullAndEmptyArrays: true,
+    },
+  },
+  {
+    $addFields: {
+      '_createdBy.user.id': { $toString: '$_createdBy.user._id' },
+      lastVersion: {
+        $arrayElemAt: ['$versions', -1],
+      },
+    },
+}];
+export const lastUpdatedByLookup = [
+  {
+    $lookup: {
+      from: 'users',
+      localField: 'lastVersion.createdBy',
+      foreignField: '_id',
+      as: '_lastUpdatedBy',
+    },
+  },
+  {
+    $addFields: {
+      _lastUpdatedBy: {
+        $arrayElemAt: ['$_lastUpdatedBy', -1],
+      },
+    },
+  },
+  {
+    $addFields: {
+      '_lastUpdatedBy.user': {
+        $ifNull: ['$_lastUpdatedBy', '$_createdBy.user'],
+      },
+    },
+  },
+  {
+    $addFields: {
+      '_lastUpdatedBy.user.id': { $toString: '$_lastUpdatedBy.user._id' },
+      lastVersion: {
+        $arrayElemAt: ['$versions', -1],
+      },
+    },
+  }
+];
+export const formLookup = [
+  {
+    $lookup: {
+      from: 'forms',
+      localField: 'form',
+      foreignField: '_id',
+      as: '_form',
+    },
+  },
+  {
+    $unwind: '$_form',
+  }
+];
+export const versionLookup = [
+  {
+    $lookup: {
+      from: 'versions',
+      localField: 'lastVersion',
+      foreignField: '_id',
+      as: 'lastVersion',
+    },
+  },
+  { $unset: 'lastVersion' }
+];

--- a/src/utils/schema/resolvers/Query/getLookup.ts
+++ b/src/utils/schema/resolvers/Query/getLookup.ts
@@ -144,6 +144,7 @@ export const getResourcesFilter = (usedFields: any, relatedFields: any) => {
  *
  * @param usedFields filter field to filter data
  * @param relatedFields form fields for reference filters
+ * @param context login user detail for build aggregation
  * @returns reference aggregation lookup query
  */
 export const getReferenceFilter = async (

--- a/src/utils/schema/resolvers/Query/getLookup.ts
+++ b/src/utils/schema/resolvers/Query/getLookup.ts
@@ -148,7 +148,8 @@ export const getResourcesFilter = (usedFields: any, relatedFields: any) => {
  */
 export const getReferenceFilter = async (
   usedFields: any,
-  relatedFields: any
+  relatedFields: any,
+  context
 ): Promise<any> => {
   const referenceDataFieldsToQuery = relatedFields.filter(
     (f) =>
@@ -171,7 +172,7 @@ export const getReferenceFilter = async (
       const referenceData = referenceDatas.find(
         (x) => x.id === field.referenceData.id
       );
-      return buildReferenceDataAggregation(referenceData, field, []);
+      return buildReferenceDataAggregation(referenceData, field, context);
     })
   );
   return linkedReferenceDataAggregation;

--- a/src/utils/schema/resolvers/Query/getLookup.ts
+++ b/src/utils/schema/resolvers/Query/getLookup.ts
@@ -150,7 +150,7 @@ export const getResourcesFilter = (usedFields: any, relatedFields: any) => {
 export const getReferenceFilter = async (
   usedFields: any,
   relatedFields: any,
-  context:any
+  context: any
 ): Promise<any> => {
   const referenceDataFieldsToQuery = relatedFields.filter(
     (f) =>

--- a/src/utils/schema/resolvers/Query/getLookup.ts
+++ b/src/utils/schema/resolvers/Query/getLookup.ts
@@ -1,3 +1,4 @@
+/** Aggregate lookup query for createdBy filter */
 export const createdByLookup = [
   {
     $lookup: {
@@ -20,7 +21,10 @@ export const createdByLookup = [
         $arrayElemAt: ['$versions', -1],
       },
     },
-}];
+  },
+];
+
+/** Aggregate lookup query for lastUpdatedBy filter */
 export const lastUpdatedByLookup = [
   {
     $lookup: {
@@ -51,8 +55,10 @@ export const lastUpdatedByLookup = [
         $arrayElemAt: ['$versions', -1],
       },
     },
-  }
+  },
 ];
+
+/** Aggregate lookup query for form filter */
 export const formLookup = [
   {
     $lookup: {
@@ -64,8 +70,10 @@ export const formLookup = [
   },
   {
     $unwind: '$_form',
-  }
+  },
 ];
+
+/** Aggregate lookup query for version filter */
 export const versionLookup = [
   {
     $lookup: {
@@ -75,5 +83,5 @@ export const versionLookup = [
       as: 'lastVersion',
     },
   },
-  { $unset: 'lastVersion' }
+  { $unset: 'lastVersion' },
 ];


### PR DESCRIPTION
# Description
We have the main query for all the records in the mutation file

In the resolver, then we are fetching some related records in multiple places: manyToManyResolvers and oneToManyResolvers. We have the possibility to pass some arguments to filter/sort records at this stage. It will work for most of the basic fields but not for advanced ones since we’re not applying any aggregation on the records and only fetching them simply.

We should refactor the main query to be able to reuse aggregations to sort and filter on complex fields.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
You can create four forms: A, B, C and D.
In form A (it will be our main one for testing the query) you can add one text question + a resourceS question targeting form B.
On form B just add one text question.
On form C add a text question + a resourcE question targeting form A.
On form D add a text question + a resourceS question targeting form A.
Then create some records for all of those forms

The idea is finally to have a grid displaying records from form A with columns referring to form B, C and D. And we would like to sort/filter those columns on complex fields such as createdBy, form, etc

# Checklist:

( * == Mandatory ) 

- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

