### PR TITLE
AB#62072 Store permissions as ObjectId not string

### DIFF
--- a/src/schema/mutation/addForm.mutation.ts
+++ b/src/schema/mutation/addForm.mutation.ts
@@ -10,6 +10,7 @@ import { buildTypes } from '@utils/schema';
 import { FormType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { status } from '@const/enumTypes';
+import mongoose from 'mongoose';
 
 /**
  * Create a new form
@@ -51,11 +52,16 @@ export default {
       user.roles
         .filter((role: Role) => !role.application)
         .map((role: Role) => role._id) || [];
+
+    const roleIds = userGlobalRoles.map((roleId) =>
+      typeof roleId === 'string' ? mongoose.Types.ObjectId(roleId) : roleId
+    );
     const defaultFormPermissions = {
-      canSee: userGlobalRoles,
-      canUpdate: userGlobalRoles,
-      canDelete: userGlobalRoles,
+      canSee: roleIds,
+      canUpdate: roleIds,
+      canDelete: roleIds,
     };
+
     const defaultResourcePermissions = {
       ...defaultFormPermissions,
       canSeeRecords: [],

--- a/src/schema/mutation/addPage.mutation.ts
+++ b/src/schema/mutation/addPage.mutation.ts
@@ -4,6 +4,7 @@ import { Application, Workflow, Dashboard, Form, Page, Role } from '@models';
 import { PageType } from '../types';
 import { ContentEnumType } from '@const/enumTypes';
 import extendAbilityForPage from '@security/extendAbilityForPage';
+import mongoose from 'mongoose';
 
 /**
  * Create a new page linked to an existing application.
@@ -87,7 +88,9 @@ export default {
       type: args.type,
       content,
       permissions: {
-        canSee: roles.map((x) => x.id),
+        canSee: roles.map((x) =>
+          typeof x.id === 'string' ? mongoose.Types.ObjectId(x.id) : x.id
+        ),
         canUpdate: [],
         canDelete: [],
       },

--- a/src/schema/mutation/addStep.mutation.ts
+++ b/src/schema/mutation/addStep.mutation.ts
@@ -79,7 +79,9 @@ export default {
         type: args.type,
         content: args.content,
         permissions: {
-          canSee: roles.map((x) => x.id),
+          canSee: roles.map((x) =>
+            typeof x.id === 'string' ? mongoose.Types.ObjectId(x.id) : x.id
+          ),
           canUpdate: [],
           canDelete: [],
         },

--- a/src/schema/mutation/duplicateApplication.mutation.ts
+++ b/src/schema/mutation/duplicateApplication.mutation.ts
@@ -9,6 +9,7 @@ import { ApplicationType } from '../types';
 import { duplicatePages } from '../../services/page.service';
 import { AppAbility } from '@security/defineUserAbility';
 import { status } from '@const/enumTypes';
+import mongoose from 'mongoose';
 
 /**
  * Create a new application from a given id.
@@ -30,6 +31,7 @@ export default {
     const ability: AppAbility = context.user.ability;
     if (ability.can('create', 'Application')) {
       const baseApplication = await Application.findById(args.application);
+
       const copiedPages = await duplicatePages(baseApplication);
       if (!baseApplication)
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
@@ -41,9 +43,21 @@ export default {
           createdBy: user._id,
           pages: copiedPages,
           permissions: {
-            canSee: baseApplication.permissions.canSee,
-            canUpdate: baseApplication.permissions.canUpdate,
-            canDelete: baseApplication.permissions.canDelete,
+            canSee: baseApplication.permissions.canSee.map((roleId) =>
+              typeof roleId === 'string'
+                ? mongoose.Types.ObjectId(roleId)
+                : roleId
+            ),
+            canUpdate: baseApplication.permissions.canUpdate.map((roleId) =>
+              typeof roleId === 'string'
+                ? mongoose.Types.ObjectId(roleId)
+                : roleId
+            ),
+            canDelete: baseApplication.permissions.canDelete.map((roleId) =>
+              typeof roleId === 'string'
+                ? mongoose.Types.ObjectId(roleId)
+                : roleId
+            ),
           },
         });
         await application.save();

--- a/src/schema/mutation/duplicatePage.mutation.ts
+++ b/src/schema/mutation/duplicatePage.mutation.ts
@@ -3,6 +3,7 @@ import { AppAbility } from '@security/defineUserAbility';
 import { PageType } from '../types';
 import { Application, Page, Role, Step, Workflow } from '@models';
 import { duplicatePage } from '../../services/page.service';
+import mongoose from 'mongoose';
 
 /**
  * Duplicate existing page in a new application.
@@ -57,7 +58,9 @@ export default {
           // Get list of roles for default permissions
           const roles = await Role.find({ application: application._id });
           const permissions = {
-            canSee: roles.map((x) => x.id),
+            canSee: roles.map((x) =>
+              typeof x.id === 'string' ? mongoose.Types.ObjectId(x.id) : x.id
+            ),
             canUpdate: [],
             canDelete: [],
           };
@@ -94,7 +97,9 @@ export default {
           // Get list of roles for default permissions
           const roles = await Role.find({ application: application._id });
           const permissions = {
-            canSee: roles.map((x) => x.id),
+            canSee: roles.map((x) =>
+              typeof x.id === 'string' ? mongoose.Types.ObjectId(x.id) : x.id
+            ),
             canUpdate: [],
             canDelete: [],
           };

--- a/src/schema/mutation/editApplication.mutation.ts
+++ b/src/schema/mutation/editApplication.mutation.ts
@@ -11,6 +11,7 @@ import { ApplicationType } from '../types';
 import { Application } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { StatusEnumType } from '@const/enumTypes';
+import mongoose from 'mongoose';
 
 /**
  * Find application from its id and update it, if user is authorized.
@@ -66,6 +67,16 @@ export default {
     const update = {
       lockedBy: user._id,
     };
+
+    // Check for role id is string or not and convert role id string to object id
+    if (args.permissions) {
+      await Object.keys(args.permissions).map(function (key) {
+        args.permissions[key] = args.permissions?.[key].map((roleId) =>
+          typeof roleId === 'string' ? mongoose.Types.ObjectId(roleId) : roleId
+        );
+      });
+    }
+
     Object.assign(
       update,
       args.name && { name: args.name },

--- a/src/schema/mutation/editReferenceData.mutation.ts
+++ b/src/schema/mutation/editReferenceData.mutation.ts
@@ -15,6 +15,7 @@ import {
   validateGraphQLFieldName,
   validateGraphQLTypeName,
 } from '@utils/validators';
+import mongoose from 'mongoose';
 
 /**
  * Edit the passed referenceData if authorized.
@@ -41,6 +42,15 @@ export default {
       throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
     }
     const ability: AppAbility = user.ability;
+
+    // Check for role id is string or not and convert role id string to object id
+    if (args.permissions) {
+      await Object.keys(args.permissions).map(function (key) {
+        args.permissions[key] = args.permissions?.[key].map((roleId) =>
+          typeof roleId === 'string' ? mongoose.Types.ObjectId(roleId) : roleId
+        );
+      });
+    }
     // Build update
     const update = {
       //modifiedAt: new Date(),

--- a/src/schema/mutation/editRole.mutation.ts
+++ b/src/schema/mutation/editRole.mutation.ts
@@ -10,7 +10,7 @@ import { get, has } from 'lodash';
 import { Role } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { RoleType } from '../types';
-
+import mongoose from 'mongoose';
 /**
  * Edit a role's admin permissions, providing its id and the list of admin permissions.
  * Throw an error if not logged or authorized.
@@ -54,9 +54,14 @@ export default {
 
     const ability: AppAbility = context.user.ability;
     const update = {};
+
     Object.assign(
       update,
-      args.permissions && { permissions: args.permissions },
+      args.permissions && {
+        permissions: args.permissions.map((roleId) =>
+          typeof roleId === 'string' ? mongoose.Types.ObjectId(roleId) : roleId
+        ),
+      },
       args.channels && { channels: args.channels },
       args.title && { title: args.title },
       args.description && { description: args.description },

--- a/src/security/defineUserAbility.ts
+++ b/src/security/defineUserAbility.ts
@@ -104,7 +104,13 @@ function filters(
   const suffix = options?.suffix ? `.${options.suffix}` : '';
   const key = `${prefix}permissions.${type}${suffix}`;
   return {
-    [key]: { $in: user.roles?.map((role) => role._id) },
+    [key]: {
+      $in: user.roles?.map((role) =>
+        typeof role._id === 'string'
+          ? mongoose.Types.ObjectId(role._id)
+          : role._id
+      ),
+    },
   };
 }
 
@@ -261,7 +267,13 @@ export default function defineUserAbility(user: User | Client): AppAbility {
     });
     // Add read access to logged user's roles
     can('read', 'Role', {
-      _id: { $in: user.roles.map((role: Role) => role._id) },
+      _id: {
+        $in: user.roles.map((role: Role) =>
+          typeof role._id === 'string'
+            ? mongoose.Types.ObjectId(role._id)
+            : role._id
+        ),
+      },
     });
   }
 

--- a/src/security/extendAbilityForPage.ts
+++ b/src/security/extendAbilityForPage.ts
@@ -6,6 +6,7 @@ import {
   conditionsMatcher,
 } from './defineUserAbility';
 import { Application, Page, User } from '@models';
+import mongoose from 'mongoose';
 
 /** Application ability class */
 const appAbility = Ability as AbilityClass<AppAbility>;
@@ -25,10 +26,13 @@ function hasApplicationPermission(
   permissionType: ObjectPermissions
 ) {
   if (!application) return false;
-  const appRoles = application.permissions[permissionType].map(
-    (role: any) => role._id
+  const appRoles = application.permissions[permissionType].map((role: any) =>
+    typeof role._id === 'string' ? mongoose.Types.ObjectId(role._id) : role._id
   );
-  const userRoles = user.roles?.map((role) => role._id);
+  const userRoles = user.roles?.map((role) =>
+    typeof role._id === 'string' ? mongoose.Types.ObjectId(role._id) : role._id
+  );
+
   return appRoles.some((role) => userRoles.includes(role));
 }
 

--- a/src/security/extendAbilityForRecords.ts
+++ b/src/security/extendAbilityForRecords.ts
@@ -12,7 +12,7 @@ import {
 } from './defineUserAbility';
 import { getFormPermissionFilter } from '@utils/filter';
 import { Form, Role, User, Resource } from '@models';
-import { Types } from 'mongoose';
+import mongoose, { Types } from 'mongoose';
 
 /** Application ability class */
 const appAbility = Ability as AbilityClass<AppAbility>;
@@ -38,8 +38,16 @@ function userCanAccessField(
   return user.roles?.some((role: Role) =>
     field.permissions?.[arrayToCheck]?.some((perm) =>
       typeof perm === 'string'
-        ? Types.ObjectId(perm).equals(role._id)
-        : perm.equals(role._id)
+        ? Types.ObjectId(perm).equals(
+            typeof role._id === 'string'
+              ? mongoose.Types.ObjectId(role._id)
+              : role._id
+          )
+        : perm.equals(
+            typeof role._id === 'string'
+              ? mongoose.Types.ObjectId(role._id)
+              : role._id
+          )
     )
   );
 }
@@ -60,7 +68,11 @@ export function userHasRoleFor(
   return user.roles?.some((role: Role) =>
     resource.permissions[type]
       ?.map((x) => (x.role ? x.role : x))
-      .includes(role._id)
+      .includes(
+        typeof role._id === 'string'
+          ? mongoose.Types.ObjectId(role._id)
+          : role._id
+      )
   );
 }
 

--- a/src/security/extendAbilityForStep.ts
+++ b/src/security/extendAbilityForStep.ts
@@ -6,6 +6,7 @@ import {
   conditionsMatcher,
 } from './defineUserAbility';
 import { Application, Page, Step, User, Workflow } from '@models';
+import mongoose from 'mongoose';
 
 /** Application ability class */
 const appAbility = Ability as AbilityClass<AppAbility>;
@@ -25,10 +26,12 @@ function hasApplicationPermission(
   permissionType: ObjectPermissions
 ) {
   if (!application) return false;
-  const appRoles = application.permissions[permissionType].map(
-    (role: any) => role._id
+  const appRoles = application.permissions[permissionType].map((role: any) =>
+    typeof role._id === 'string' ? mongoose.Types.ObjectId(role._id) : role._id
   );
-  const userRoles = user.roles?.map((role) => role._id);
+  const userRoles = user.roles?.map((role) =>
+    typeof role._id === 'string' ? mongoose.Types.ObjectId(role._id) : role._id
+  );
   return appRoles.some((role) => userRoles.includes(role));
 }
 


### PR DESCRIPTION
# Description
Sometimes permissions are stored as string and some other times as objectIDs.
We only want to store them as ObjectIds.
You should check each call to the db dealing with permissions and make sure they are typed correctly.
You should also set up a migration to convert all of them and make sure we only have unique roles in an array.

## Ticket
https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/62072

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

