### PR TITLE
Feat/ab#11064 abc prevent admin to remove fields that are used on grids, workflow or pull jobs

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -54,7 +54,6 @@
 			},
 			"edit": {
 				"errors": {
-					"alreadyUseAggregationField": "This Field is used in {{name}}. So,don't remove any fields from aggregation.",
 					"invalidArguments": "Resource and aggregation and aggregation id must be provided when you are update Aggregation"
 				}
 			}
@@ -161,7 +160,6 @@
 			},
 			"edit": {
 				"errors": {
-					"alreadyUseLayoutField": "This Field is used in {{name}}. So,don't remove any fields from layout.",
 					"invalidAddPageArguments": "Page type must be an available type and linked application ID must be provided."
 				}
 			}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -54,6 +54,7 @@
 			},
 			"edit": {
 				"errors": {
+					"alreadyUseAggregationField": "This Field is used in {{name}}. So,don't remove any fields from aggregation.",
 					"invalidArguments": "Resource and aggregation and aggregation id must be provided when you are update Aggregation"
 				}
 			}
@@ -160,6 +161,7 @@
 			},
 			"edit": {
 				"errors": {
+					"alreadyUseLayoutField": "This Field is used in {{name}}. So,don't remove any fields from layout.",
 					"invalidAddPageArguments": "Page type must be an available type and linked application ID must be provided."
 				}
 			}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -131,6 +131,8 @@
 				"errors": {
 					"alreadyUseFormField": "This Field is used in {{name}}. So,don't remove any fields from form.",
 					"coreFieldMissing": "Core field missing : {{name}}. Please implement this field.",
+					"invalidArguments": "structure or form id must be provided.",
+					"invalidArgumentsEditStructure": "structure and form id must be provided.",
 					"relatedNameDuplicated": "Related name duplicated : {{name}}. The target Resource already contains a field with that name. Please provide a different name."
 				}
 			}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -129,6 +129,7 @@
 			},
 			"edit": {
 				"errors": {
+					"alreadyUseFormField": "This Field is used in {{name}}. So,don't remove any fields from form.",
 					"coreFieldMissing": "Core field missing : {{name}}. Please implement this field.",
 					"relatedNameDuplicated": "Related name duplicated : {{name}}. The target Resource already contains a field with that name. Please provide a different name."
 				}

--- a/src/i18n/test.json
+++ b/src/i18n/test.json
@@ -129,6 +129,7 @@
 			},
 			"edit": {
 				"errors": {
+					"alreadyUseFormField": "****** {{name}} ******",
 					"coreFieldMissing": "****** {{name}} ******",
 					"relatedNameDuplicated": "****** {{name}} ******"
 				}

--- a/src/i18n/test.json
+++ b/src/i18n/test.json
@@ -54,7 +54,6 @@
 			},
 			"edit": {
 				"errors": {
-					"alreadyUseAggregationField": "****** {{name}} ******",
 					"invalidArguments": "******"
 				}
 			}
@@ -161,7 +160,6 @@
 			},
 			"edit": {
 				"errors": {
-					"alreadyUseLayoutField": "****** {{name}} ******",
 					"invalidAddPageArguments": "******"
 				}
 			}

--- a/src/i18n/test.json
+++ b/src/i18n/test.json
@@ -131,6 +131,8 @@
 				"errors": {
 					"alreadyUseFormField": "****** {{name}} ******",
 					"coreFieldMissing": "****** {{name}} ******",
+					"invalidArguments": "******",
+					"invalidArgumentsEditStructure": "******",
 					"relatedNameDuplicated": "****** {{name}} ******"
 				}
 			}

--- a/src/i18n/test.json
+++ b/src/i18n/test.json
@@ -54,6 +54,7 @@
 			},
 			"edit": {
 				"errors": {
+					"alreadyUseAggregationField": "****** {{name}} ******",
 					"invalidArguments": "******"
 				}
 			}
@@ -160,6 +161,7 @@
 			},
 			"edit": {
 				"errors": {
+					"alreadyUseLayoutField": "****** {{name}} ******",
 					"invalidAddPageArguments": "******"
 				}
 			}

--- a/src/routes/editformfirlduseschecking/index.ts
+++ b/src/routes/editformfirlduseschecking/index.ts
@@ -1,0 +1,182 @@
+import express from 'express';
+import i18next from 'i18next';
+import { logger } from '../../services/logger.service';
+import { Dashboard, Form, PullJob, Resource } from '@models';
+import { isEqual } from 'lodash';
+
+/**
+ * check form field check in layout / aggregation / widget / pull jobs
+ */
+const router = express.Router();
+
+/**
+ * Build check form field uses
+ *
+ * @param req current http request
+ * @param res http response
+ * @returns check form field uses
+ */
+
+/**
+ * check field use of the platform,
+ * if a check fields with ids is not provided in the body, export all of them
+ */
+router.post('/', async (req, res) => {
+  try {
+    const args = req.body;
+    if (!args.id && !args.structure) {
+      return res
+        .status(400)
+        .send(
+          i18next.t('mutations.form.edit.errors.invalidArgumentsEditStructure')
+        );
+    }
+
+    //get form data
+    const form = await Form.findById(args.id);
+    let alreadyUseField = false;
+    let usedFieldName: any;
+    if (args.structure && !isEqual(form.structure, args.structure)) {
+      //form data use or not and check forcefully update this form fields..
+      if (!!form && !!form.fields) {
+        //form fields are use or not in resource layout..
+        if (alreadyUseField == false) {
+          const resourceData = await Resource.findById(form.resource);
+          if (!!form.resource && !!resourceData && !!resourceData.layouts) {
+            outerloop: for (let i = 0; i < form.fields.length; i++) {
+              for (let j = 0; j < resourceData.layouts.length; j++) {
+                if (
+                  !!resourceData.layouts[j].query &&
+                  !!resourceData.layouts[j].query.fields
+                ) {
+                  for (
+                    let k = 0;
+                    k < resourceData.layouts[j].query.fields.length;
+                    k++
+                  ) {
+                    if (
+                      resourceData.layouts[j].query.fields[k].name ===
+                      form.fields[i].name
+                    ) {
+                      alreadyUseField = true;
+                      usedFieldName = 'layout';
+                      break outerloop;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        //form fields are use or not in resource aggregation..
+        if (alreadyUseField == false) {
+          const resourceData = await Resource.findById(form.resource);
+          if (
+            !!form.resource &&
+            !!resourceData &&
+            !!resourceData.aggregations
+          ) {
+            outerloop: for (let i = 0; i < form.fields.length; i++) {
+              for (let j = 0; j < resourceData.aggregations.length; j++) {
+                if (!!resourceData.aggregations[j].sourceFields) {
+                  for (
+                    let k = 0;
+                    k < resourceData.aggregations[j].sourceFields.length;
+                    k++
+                  ) {
+                    if (
+                      resourceData.aggregations[j].sourceFields[k] ===
+                      form.fields[i].name
+                    ) {
+                      alreadyUseField = true;
+                      usedFieldName = 'aggregation';
+                      break outerloop;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        //form fields are use or not in pull jobs..
+        if (alreadyUseField == false) {
+          const pullJobData = await PullJob.findOne({ convertTo: args.id });
+          if (!!pullJobData && !!pullJobData.mapping) {
+            outerloop: for (let i = 0; i < form.fields.length; i++) {
+              for (
+                let j = 0;
+                j < Object.keys(pullJobData.mapping).length;
+                j++
+              ) {
+                if (
+                  Object.keys(pullJobData.mapping)[j] === form.fields[i].name
+                ) {
+                  alreadyUseField = true;
+                  usedFieldName = 'pull job';
+                  break outerloop;
+                }
+              }
+            }
+          }
+        }
+
+        //form fields are use or not in widget..
+        if (alreadyUseField == false) {
+          const widgetData = await Dashboard.find({
+            structure: {
+              $elemMatch: {
+                'settings.resource': form.resource.toString(),
+              },
+            },
+          });
+
+          if (!!widgetData) {
+            outerloop: for (let i = 0; i < form.fields.length; i++) {
+              for (let j = 0; j < widgetData.length; j++) {
+                for (let k = 0; k < widgetData[j].structure.length; k++) {
+                  if (
+                    !!widgetData[j].structure[k].settings &&
+                    widgetData[j].structure[k].settings &&
+                    !!widgetData[j].structure[k].settings.query &&
+                    !!widgetData[j].structure[k].settings.query.fields
+                  ) {
+                    const dashboardField =
+                      widgetData[j].structure[k].settings.query.fields;
+                    if (!!dashboardField) {
+                      for (let m = 0; m < dashboardField.length; m++) {
+                        if (dashboardField[m].name === form.fields[i].name) {
+                          alreadyUseField = true;
+                          usedFieldName = 'widget';
+                          break outerloop;
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      if (alreadyUseField) {
+        // If use form field in layout / aggregation / pull jobs / widget than showing popup
+        return res.status(200).send({
+          status: 'Use form field',
+          message: i18next.t('mutations.form.edit.errors.alreadyUseFormField', {
+            name: usedFieldName,
+          }),
+          structure: args.structure,
+        });
+      }
+    }
+    return res.status(200).send({ status: 'OK' });
+  } catch (err) {
+    logger.error(err.message, { stack: err.stack });
+    return res.status(500).send(req.t('common.errors.internalServerError'));
+  }
+});
+
+export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -10,6 +10,7 @@ import permissions from './permissions';
 import roles from './roles';
 import gis from './gis';
 import style from './style';
+import editformfirlduseschecking from './editformfirlduseschecking';
 
 /** Express router instance */
 const router = express.Router();
@@ -26,5 +27,6 @@ router.use('/summarycards', summarycards);
 router.use('/roles', roles);
 router.use('/gis', gis);
 router.use('/style', style);
+router.use('/editformfirlduseschecking', editformfirlduseschecking);
 
 export { router };

--- a/src/schema/mutation/editAggregation.mutation.ts
+++ b/src/schema/mutation/editAggregation.mutation.ts
@@ -1,9 +1,9 @@
 import { GraphQLError, GraphQLID, GraphQLNonNull } from 'graphql';
-import { Resource } from '@models';
+import { Dashboard, Resource } from '@models';
 import { AggregationType } from '../../schema/types';
 import { AppAbility } from '@security/defineUserAbility';
 import AggregationInputType from '../../schema/inputs/aggregation.input';
-import { logger } from '@services/logger.service';
+// import { logger } from '@services/logger.service';
 
 /**
  * Edit existing aggregation.
@@ -17,47 +17,107 @@ export default {
     resource: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try {
-      if (!args.resource || !args.aggregation) {
-        throw new GraphQLError(
-          context.i18next.t(
-            'mutations.aggregation.edit.errors.invalidArguments'
-          )
-        );
-      }
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = user.ability;
-      // Edition of a resource
-      if (args.resource) {
-        const filters = Resource.accessibleBy(ability, 'update')
-          .where({ _id: args.resource })
-          .getFilter();
-        const resource: Resource = await Resource.findOne(filters);
-        if (!resource) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.permissionNotGranted')
-          );
-        }
-
-        resource.aggregations.id(args.id).sourceFields =
-          args.aggregation.sourceFields;
-        resource.aggregations.id(args.id).pipeline = args.aggregation.pipeline;
-        resource.aggregations.id(args.id).mapping = args.aggregation.mapping;
-        resource.aggregations.id(args.id).name = args.aggregation.name;
-
-        await resource.save();
-        return resource.aggregations.id(args.id);
-      }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
+    // try {
+    if (!args.resource || !args.aggregation) {
       throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
+        context.i18next.t('mutations.aggregation.edit.errors.invalidArguments')
       );
     }
+
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+    const ability: AppAbility = user.ability;
+    // Edition of a resource
+    if (args.resource) {
+      //get resource aggregation data
+      const resourceData = await Resource.findOne({
+        aggregations: {
+          $elemMatch: { _id: args.id },
+        },
+      });
+
+      if (!args.forceFullyUpdateFields) {
+        args.forceFullyUpdateFields = false;
+      }
+      //check aggregation data available or not and check forcefully update this aggregation fields..
+      if (
+        !!resourceData &&
+        !!resourceData.aggregations &&
+        args.forceFullyUpdateFields == false
+      ) {
+        //get widget data
+        const widgetData = await Dashboard.find({
+          structure: {
+            $elemMatch: { 'settings.resource': resourceData._id },
+          },
+        });
+
+        //check widget data available or not.
+        if (!!widgetData) {
+          //aggregation field are use or not in widget..
+          for (
+            let i = 0;
+            i < resourceData.aggregations[0].sourceFields.length;
+            i++
+          ) {
+            for (let j = 0; j < widgetData.length; j++) {
+              if (!!widgetData[j].structure) {
+                for (let k = 0; k < widgetData[j].structure.length; k++) {
+                  if (
+                    !!widgetData[j].structure[k].settings &&
+                    !!widgetData[j].structure[k].settings.query &&
+                    !!widgetData[j].structure[k].settings.query.fields
+                  ) {
+                    const dashboardField =
+                      widgetData[j].structure[k].settings.query.fields;
+                    for (let m = 0; m < dashboardField.length; m++) {
+                      if (
+                        dashboardField[m].name ===
+                        resourceData.aggregations[0].sourceFields[i]
+                      ) {
+                        // If use aggregation field in widget than showing popup
+                        throw new GraphQLError(
+                          context.i18next.t(
+                            'mutations.form.edit.errors.alreadyUseFormField',
+                            {
+                              name: 'widget',
+                            }
+                          )
+                        );
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      const filters = Resource.accessibleBy(ability, 'update')
+        .where({ _id: args.resource })
+        .getFilter();
+      const resource: Resource = await Resource.findOne(filters);
+      if (!resource) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      resource.aggregations.id(args.id).sourceFields =
+        args.aggregation.sourceFields;
+      resource.aggregations.id(args.id).pipeline = args.aggregation.pipeline;
+      resource.aggregations.id(args.id).mapping = args.aggregation.mapping;
+      resource.aggregations.id(args.id).name = args.aggregation.name;
+
+      await resource.save();
+      return resource.aggregations.id(args.id);
+    }
+    // } catch (err) {
+    //   logger.error(err.message, { stack: err.stack });
+    //   throw new GraphQLError(
+    //     context.i18next.t('common.errors.internalServerError')
+    //   );
+    // }
   },
 };

--- a/src/schema/mutation/editAggregation.mutation.ts
+++ b/src/schema/mutation/editAggregation.mutation.ts
@@ -49,50 +49,32 @@ export default {
       ) {
         //get widget data
         const widgetData = await Dashboard.find({
-          structure: {
-            $elemMatch: { 'settings.resource': resourceData._id },
-          },
+          $and: [
+            {
+              structure: {
+                $elemMatch: {
+                  'settings.resource': resourceData._id.toString(),
+                },
+              },
+            },
+            {
+              structure: {
+                $elemMatch: { 'settings.aggregations': args.id.toString() },
+              },
+            },
+          ],
         });
 
         //check widget data available or not.
         if (!!widgetData) {
-          //aggregation field are use or not in widget..
-          for (
-            let i = 0;
-            i < resourceData.aggregations[0].sourceFields.length;
-            i++
-          ) {
-            for (let j = 0; j < widgetData.length; j++) {
-              if (!!widgetData[j].structure) {
-                for (let k = 0; k < widgetData[j].structure.length; k++) {
-                  if (
-                    !!widgetData[j].structure[k].settings &&
-                    !!widgetData[j].structure[k].settings.query &&
-                    !!widgetData[j].structure[k].settings.query.fields
-                  ) {
-                    const dashboardField =
-                      widgetData[j].structure[k].settings.query.fields;
-                    for (let m = 0; m < dashboardField.length; m++) {
-                      if (
-                        dashboardField[m].name ===
-                        resourceData.aggregations[0].sourceFields[i]
-                      ) {
-                        // If use aggregation field in widget than showing popup
-                        throw new GraphQLError(
-                          context.i18next.t(
-                            'mutations.form.edit.errors.alreadyUseFormField',
-                            {
-                              name: 'widget',
-                            }
-                          )
-                        );
-                      }
-                    }
-                  }
-                }
+          throw new GraphQLError(
+            context.i18next.t(
+              'mutations.aggregation.edit.errors.alreadyUseAggregationField',
+              {
+                name: 'widget',
               }
-            }
-          }
+            )
+          );
         }
       }
       const filters = Resource.accessibleBy(ability, 'update')

--- a/src/schema/mutation/editAggregation.mutation.ts
+++ b/src/schema/mutation/editAggregation.mutation.ts
@@ -1,9 +1,9 @@
 import { GraphQLError, GraphQLID, GraphQLNonNull } from 'graphql';
-import { Dashboard, Resource } from '@models';
+import { Resource } from '@models';
 import { AggregationType } from '../../schema/types';
 import { AppAbility } from '@security/defineUserAbility';
 import AggregationInputType from '../../schema/inputs/aggregation.input';
-// import { logger } from '@services/logger.service';
+import { logger } from '@services/logger.service';
 
 /**
  * Edit existing aggregation.
@@ -17,89 +17,47 @@ export default {
     resource: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    // try {
-    if (!args.resource || !args.aggregation) {
-      throw new GraphQLError(
-        context.i18next.t('mutations.aggregation.edit.errors.invalidArguments')
-      );
-    }
-
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-    const ability: AppAbility = user.ability;
-    // Edition of a resource
-    if (args.resource) {
-      //get resource aggregation data
-      const resourceData = await Resource.findOne({
-        aggregations: {
-          $elemMatch: { _id: args.id },
-        },
-      });
-
-      if (!args.forceFullyUpdateFields) {
-        args.forceFullyUpdateFields = false;
-      }
-      //check aggregation data available or not and check forcefully update this aggregation fields..
-      if (
-        !!resourceData &&
-        !!resourceData.aggregations &&
-        args.forceFullyUpdateFields == false
-      ) {
-        //get widget data
-        const widgetData = await Dashboard.find({
-          $and: [
-            {
-              structure: {
-                $elemMatch: {
-                  'settings.resource': resourceData._id.toString(),
-                },
-              },
-            },
-            {
-              structure: {
-                $elemMatch: { 'settings.aggregations': args.id.toString() },
-              },
-            },
-          ],
-        });
-
-        //check widget data available or not.
-        if (!!widgetData) {
-          throw new GraphQLError(
-            context.i18next.t(
-              'mutations.aggregation.edit.errors.alreadyUseAggregationField',
-              {
-                name: 'widget',
-              }
-            )
-          );
-        }
-      }
-      const filters = Resource.accessibleBy(ability, 'update')
-        .where({ _id: args.resource })
-        .getFilter();
-      const resource: Resource = await Resource.findOne(filters);
-      if (!resource) {
+    try {
+      if (!args.resource || !args.aggregation) {
         throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
+          context.i18next.t(
+            'mutations.aggregation.edit.errors.invalidArguments'
+          )
         );
       }
-      resource.aggregations.id(args.id).sourceFields =
-        args.aggregation.sourceFields;
-      resource.aggregations.id(args.id).pipeline = args.aggregation.pipeline;
-      resource.aggregations.id(args.id).mapping = args.aggregation.mapping;
-      resource.aggregations.id(args.id).name = args.aggregation.name;
 
-      await resource.save();
-      return resource.aggregations.id(args.id);
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
+      }
+      const ability: AppAbility = user.ability;
+      // Edition of a resource
+      if (args.resource) {
+        const filters = Resource.accessibleBy(ability, 'update')
+          .where({ _id: args.resource })
+          .getFilter();
+        const resource: Resource = await Resource.findOne(filters);
+        if (!resource) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.permissionNotGranted')
+          );
+        }
+        resource.aggregations.id(args.id).sourceFields =
+          args.aggregation.sourceFields;
+        resource.aggregations.id(args.id).pipeline = args.aggregation.pipeline;
+        resource.aggregations.id(args.id).mapping = args.aggregation.mapping;
+        resource.aggregations.id(args.id).name = args.aggregation.name;
+
+        await resource.save();
+        return resource.aggregations.id(args.id);
+      }
+    } catch (err) {
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-    // } catch (err) {
-    //   logger.error(err.message, { stack: err.stack });
-    //   throw new GraphQLError(
-    //     context.i18next.t('common.errors.internalServerError')
-    //   );
-    // }
   },
 };

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -5,15 +5,7 @@ import {
   GraphQLError,
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
-import {
-  Form,
-  Resource,
-  Version,
-  Channel,
-  ReferenceData,
-  PullJob,
-  Dashboard,
-} from '@models';
+import { Form, Resource, Version, Channel, ReferenceData } from '@models';
 import { buildTypes } from '@utils/schema';
 import {
   removeField,
@@ -564,12 +556,17 @@ export default {
         update.$push = { versions: version._id };
       }
       // Return updated form
-      return Form.findByIdAndUpdate(args.id, update, { new: true }, () => {
-        // Avoid to rebuild types only if permissions changed
-        if (args.name || args.status || args.structure) {
-          buildTypes();
+      return await Form.findByIdAndUpdate(
+        args.id,
+        update,
+        { new: true },
+        () => {
+          // Avoid to rebuild types only if permissions changed
+          if (args.name || args.status || args.structure) {
+            buildTypes();
+          }
         }
-      });
+      );
     } catch (err) {
       logger.error(err.message, { stack: err.stack });
       throw new GraphQLError(

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -31,7 +31,7 @@ import differenceWith from 'lodash/differenceWith';
 import unionWith from 'lodash/unionWith';
 import i18next from 'i18next';
 import { isArray } from 'lodash';
-import { logger } from '@services/logger.service';
+// import { logger } from '@services/logger.service';
 
 /**
  * List of keys of the structure's object which we want to inherit to the children forms when they are modified on the core form
@@ -602,7 +602,7 @@ export default {
       update.$push = { versions: version._id };
     }
     // Return updated form
-    return await Form.findByIdAndUpdate(args.id, update, { new: true }, () => {
+    return Form.findByIdAndUpdate(args.id, update, { new: true }, () => {
       // Avoid to rebuild types only if permissions changed
       if (args.name || args.status || args.structure) {
         buildTypes();

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -615,7 +615,7 @@ export default {
                 const layoutData = [];
                 resourceData.layouts.map(async function (result) {
                   if (!!result.query && !!result.query.fields) {
-                    let layoutFields = [];
+                    const layoutFields = [];
                     result.query.fields.map(async function (layout) {
                       if (items.name !== layout.name) {
                         layoutFields.push(layout);
@@ -642,7 +642,7 @@ export default {
                 const aggregationData = [];
                 resourceData.aggregations.map(async function (result) {
                   if (!!result.sourceFields && !!result.sourceFields) {
-                    let aggregationFields = [];
+                    const aggregationFields = [];
                     result.sourceFields.map(async function (aggregation) {
                       if (items.name !== aggregation) {
                         aggregationFields.push(aggregation);

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -5,7 +5,14 @@ import {
   GraphQLError,
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
-import { Form, Resource, Version, Channel, ReferenceData } from '@models';
+import {
+  Form,
+  Resource,
+  Version,
+  Channel,
+  ReferenceData,
+  PullJob,
+} from '@models';
 import { buildTypes } from '@utils/schema';
 import {
   removeField,
@@ -79,441 +86,533 @@ export default {
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    try {
-      // Authentication check
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
+    // try {
+    // Authentication check
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
 
-      // Permission check
-      const ability: AppAbility = user.ability;
-      const form = await Form.findById(args.id);
-      if (ability.cannot('update', form)) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-
-      // Initialize the update object --- TODO = put interface
-      /* const update: any = {
-    modifiedAt: new Date(),
-  }; */
-      const update: any = {};
-
-      // Update name
-      if (args.name) {
-        const graphQLTypeName = Form.getGraphQLTypeName(args.name);
-        validateGraphQLTypeName(
-          Form.getGraphQLTypeName(args.name),
-          context.i18next
-        );
-        if (
-          (await Form.hasDuplicate(graphQLTypeName, form.id)) ||
-          (await ReferenceData.hasDuplicate(graphQLTypeName))
-        ) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.duplicatedGraphQLTypeName')
-          );
-        }
-        update.name = args.name;
-        update.graphQLTypeName = Form.getGraphQLTypeName(args.name);
-        if (form.core) {
-          await Resource.findByIdAndUpdate(form.resource, {
-            name: args.name,
-          });
-        }
-      }
-
-      // Update status
-      if (args.status) {
-        update.status = args.status;
-        // Activate the form.
-        if (update.status === status.active) {
-          // Create notification channel
-          const notificationChannel = new Channel({
-            title: `Form - ${form.name}`,
-            form: form._id,
-          });
-          await notificationChannel.save();
-          update.channel = notificationChannel.form;
-        } else {
-          // Deactivate the form
-          // delete channel and notifications if form not active anymore
-          const channel = await Channel.findOneAndDelete({ form: form._id });
-          if (channel) {
-            update.channel = [];
-          }
-        }
-      }
-
-      // Update permissions
-      if (args.permissions) {
-        const permissions: PermissionChange = args.permissions;
-        for (const permission in permissions) {
-          if (isArray(permissions[permission])) {
-            // if it's an array, replace the old value with the provided list
-            update['permissions.' + permission] = permissions[permission];
-          } else {
-            const obj = permissions[permission];
-            if (obj.add && obj.add.length) {
-              const pushRoles = {
-                [`permissions.${permission}`]: { $each: obj.add },
-              };
-
-              if (update.$addToSet) Object.assign(update.$addToSet, pushRoles);
-              else Object.assign(update, { $addToSet: pushRoles });
-            }
-            if (obj.remove && obj.remove.length) {
-              let pullRoles: any;
-
-              if (typeof obj.remove[0] === 'string') {
-                // CanSee, canUpdate, canDelete, canCreateRecords
-                pullRoles = {
-                  [`permissions.${permission}`]: {
-                    $in: obj.remove.map(
-                      (role: any) => new mongoose.Types.ObjectId(role)
-                    ),
-                  },
-                };
-              } else {
-                // canSeeRecords, canUpdateRecords, canDeleteRecords, recordsUnicity
-                pullRoles = {
-                  [`permissions.${permission}`]: {
-                    $in: obj.remove.map((perm: any) =>
-                      perm.access
-                        ? {
-                            role: new mongoose.Types.ObjectId(perm.role),
-                            access: perm.access,
-                          }
-                        : {
-                            role: new mongoose.Types.ObjectId(perm.role),
-                          }
-                    ),
-                  },
-                };
-              }
-
-              if (update.$pull) Object.assign(update.$pull, pullRoles);
-              else Object.assign(update, { $pull: pullRoles });
-            }
-          }
-        }
-      }
-
-      // Update fields and structure, check that structure is different
-      if (args.structure && !isEqual(form.structure, args.structure)) {
-        update.structure = args.structure;
-        const structure = JSON.parse(args.structure);
-        const fields = [];
-        for (const page of structure.pages) {
-          await extractFields(page, fields, form.core);
-          findDuplicateFields(fields);
-          for (const field of fields.filter((x) =>
-            ['resource', 'resources'].includes(x.type)
-          )) {
-            // Raises an error if the field is already used as related name for this resource
-            if (
-              await Form.findOne({
-                fields: {
-                  $elemMatch: {
-                    resource: field.resource,
-                    relatedName: field.relatedName,
-                  },
-                },
-                _id: { $ne: form.id },
-                ...(form.resource && { resource: { $ne: form.resource } }),
-              })
-            ) {
-              throw new GraphQLError(
-                i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
-                  name: field.relatedName,
-                })
-              );
-            }
-            // Raises an error if the field exists in the resource
-            if (
-              await Resource.findOne({
-                fields: { $elemMatch: { name: field.relatedName } },
-                _id: field.resource,
-              })
-            ) {
-              throw new GraphQLError(
-                i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
-                  name: field.relatedName,
-                })
-              );
-            }
-          }
-        }
-        // === Resource inheritance management ===
-        const prevStructure = JSON.parse(
-          form.structure ? form.structure : '{}'
-        ); // Get the current form's state structure
-        if (form.resource && !isEqual(prevStructure, structure)) {
-          // If the form has a resource and its structure has changed
-          const resource = await Resource.findById(form.resource);
-          const templates = await Form.find({
-            resource: form.resource,
-            _id: { $ne: mongoose.Types.ObjectId(args.id) },
-          }).select('_id structure fields');
-          const oldFields: any[] = JSON.parse(JSON.stringify(resource.fields));
-          const usedFields = templates
-            .map((x) => x.fields)
-            .flat()
-            .concat(fields);
-          // Check fields against the resource to add new ones or edit old ones
-          for (const field of fields) {
-            // For each field in the form being saved
-            const oldField = oldFields.find((x) => x.name === field.name); // Find the equivalent field in the resource's fields
-            if (!oldField) {
-              // If the field isn't found in the resource
-              const newField: any = Object.assign({}, field); // Create a copy of the form's field
-              newField.isRequired =
-                form.core && field.isRequired ? true : false; // If it's a core form and the field isRequired, copy this property
-              oldFields.push(newField); // Add this field to the list of the resource's fields
-            } else {
-              // Check if field can be updated
-              if (!oldField.isCore || (oldField.isCore && form.core)) {
-                // If resource's field isn't core or if it's core but the edited form is core too, make it writable
-                const storedFieldChanged = !isEqual(oldField, field);
-                if (storedFieldChanged) {
-                  // Inherit the field's permissions
-                  field.permissions = oldField.permissions;
-                  // If the resource's field and the current form's field are different
-                  const index = oldFields.findIndex(
-                    (x) => x.name === field.name
-                  ); // Get the index of the form's field in the resources
-                  oldFields.splice(index, 1, field); // Replace resource's field by the form's field
-                }
-                for (const template of templates) {
-                  // For each form that inherits from the same resource
-                  if (storedFieldChanged) {
-                    template.fields = template.fields.map((x) => {
-                      // For each field of the childForm
-                      return x.name === field.name // If the child field's name equals the parent field's name
-                        ? x.hasOwnProperty('defaultValue') &&
-                          !isEqual(x.defaultValue, oldField.defaultValue) // If the child possesses the "defaultValue" property
-                          ? { ...field, defaultValue: x.defaultValue } // Replace child's field by parent's field with child's field defaultValue's value
-                          : field // Else replace child's field by parent's field
-                        : x; // Else don't change the child's field
-                    });
-                  }
-                  if (!field.generated) {
-                    // Update structure
-                    const newStructure = JSON.parse(template.structure); // Get the inheriting form's structure
-                    replaceField(
-                      field.name,
-                      newStructure,
-                      structure,
-                      prevStructure
-                    ); // Replace the inheriting form's field by the edited form's field
-                    template.structure = JSON.stringify(newStructure); // Save the new structure
-                  }
-                }
-              }
-            }
-          }
-          // Check if there are unused or duplicated fields in the resource
-          for (let index = 0; index < oldFields.length; index++) {
-            const field = oldFields[index]; // Store the resource's field
-            if (!field.isCalculated) {
-              // prevent calculated fields to be deleted automatically
-              const fieldToRemove =
-                ((form.core
-                  ? !fields.some((x) => x.name === field.name)
-                  : true) && // If edited form is core, check if resource's field is absent from form's fields
-                  !usedFields.some((x) => x.name === field.name)) || // Unused -- TODO What if it's in one inherited form and not in another ?
-                oldFields.some(
-                  (x, id) => field.name === x.name && id !== index
-                ); // Duplicated If there's another field with the same name but not the same ID
-              if (fieldToRemove) {
-                oldFields.splice(index, 1);
-                index--;
-              }
-            }
-          }
-          // Check if form is a core template of a resource
-          if (!form.core) {
-            // Check if a required field is missing
-            // Keep old version and move that to extract fields ?
-            let fieldExists = false;
-            for (const field of oldFields.filter((x) => x.isCore)) {
-              // For each non-core field in the resource
-              for (const x of fields) {
-                if (x.name === field.name) {
-                  x.isCore = true;
-                  fieldExists = true;
-                }
-              }
-              if (!fieldExists) {
-                throw new GraphQLError(
-                  i18next.t('mutations.form.edit.errors.coreFieldMissing', {
-                    name: field.name,
-                  })
-                );
-              }
-              fieldExists = false;
-            }
-          } else {
-            // List deleted fields
-            const deletedFields = form.fields.filter(
-              (x) => !fields.some((y) => x.name === y.name)
-            );
-            // List new fields
-            const newFields = fields.filter(
-              (x) => !form.fields.some((y) => x.name === y.name)
-            );
-            // Detect structure updates
-            const structureUpdate = {};
-            const newStructure = structure;
-            if (form.structure) {
-              // Store the property's objects that have been removed between the new and previous versions of the form
-              for (const property of INHERITED_PROPERTIES) {
-                if (!isEqual(prevStructure[property], newStructure[property])) {
-                  structureUpdate[property] = newStructure[property]
-                    ? differenceWith(
-                        prevStructure[property],
-                        newStructure[property],
-                        isEqual
-                      )
-                    : prevStructure[property];
-                }
-              }
-            }
-
-            // Loop on templates
-            for (const template of templates) {
-              // === REFLECT DELETION ===
-              // For each old field from core form which is not anymore in the current core form fields
-              for (const field of deletedFields) {
-                // Check if we rename or delete a field used in a child form
-                if (usedFields.some((x) => x.name === field.name)) {
-                  // If this deleted / modified field was used, reflect the deletion / edition
-                  const index = template.fields.findIndex(
-                    (x) => x.name === field.name
-                  );
-                  template.fields.splice(index, 1);
-                  if (!field.generated) {
-                    // Remove from structure
-                    const templateStructure = JSON.parse(template.structure);
-                    removeField(templateStructure, field.name);
-                    template.structure = JSON.stringify(templateStructure);
-                  }
-                }
-              }
-
-              // === REFLECT ADDITION ===
-              // For each new field from core form which were not before in the old core form fields
-              for (const field of newFields) {
-                // Add to fields and structure if needed
-                if (!template.fields.some((x) => x.name === field.name)) {
-                  template.fields.unshift(field);
-
-                  if (!field.generated) {
-                    // Add to structure
-                    const templateStructure = JSON.parse(template.structure);
-                    addField(templateStructure, field.name, structure);
-                    template.structure = JSON.stringify(templateStructure);
-                  }
-                }
-              }
-
-              // REFLECT STRUCTURE CHANGES ===
-              const templateStructure = JSON.parse(template.structure);
-              for (const objectKey in structureUpdate) {
-                // In a childForm's structure, if there are property's objects that have been deleted from the core form, delete them there too
-                if (
-                  templateStructure[objectKey] &&
-                  templateStructure[objectKey].length &&
-                  structureUpdate[objectKey] &&
-                  structureUpdate[objectKey].length
-                ) {
-                  templateStructure[objectKey] = differenceWith(
-                    templateStructure[objectKey],
-                    structureUpdate[objectKey],
-                    isEqual
-                  );
-                }
-                // Merge the new property's objects to the children
-                templateStructure[objectKey] = templateStructure[objectKey]
-                  ? unionWith(
-                      templateStructure[objectKey],
-                      newStructure[objectKey],
-                      isEqual
-                    )
-                  : newStructure[objectKey];
-                // If the property is null, undefined or empty, directly remove the entry from the structure
-                if (
-                  !templateStructure[objectKey] ||
-                  !templateStructure[objectKey].length
-                ) {
-                  delete templateStructure[objectKey];
-                }
-              }
-              template.structure = JSON.stringify(templateStructure);
-            }
-
-            for (const field of deletedFields) {
-              // We remove the field from the resource
-              const index = oldFields.findIndex((x) => x.name === field.name);
-              if (index >= 0) {
-                oldFields.splice(index, 1);
-              }
-            }
-          }
-
-          // Build bulk update of non-core templates
-          const bulkUpdate = [];
-          for (const template of templates) {
-            bulkUpdate.push({
-              updateOne: {
-                filter: { _id: template._id },
-                update: {
-                  structure: template.structure,
-                  fields: template.fields,
-                },
-              },
-            });
-          }
-          if (bulkUpdate.length > 0) {
-            // Update all child form for addition/deletion/structure changes
-            await Form.bulkWrite(bulkUpdate);
-          }
-
-          // Update resource fields
-          await Resource.findByIdAndUpdate(form.resource, {
-            fields: oldFields,
-          });
-        }
-        update.fields = fields;
-        // Update version
-        const version = new Version({
-          //createdAt: form.modifiedAt ? form.modifiedAt : form.createdAt,
-          data: form.structure,
-        });
-        await version.save();
-        update.$push = { versions: version._id };
-      }
-      // Return updated form
-      return await Form.findByIdAndUpdate(
-        args.id,
-        update,
-        { new: true },
-        () => {
-          // Avoid to rebuild types only if permissions changed
-          if (args.name || args.status || args.structure) {
-            buildTypes();
-          }
-        }
-      );
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
+    // Permission check
+    const ability: AppAbility = user.ability;
+    const form = await Form.findById(args.id);
+    if (ability.cannot('update', form)) {
       throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
+        context.i18next.t('common.errors.permissionNotGranted')
       );
     }
+
+    // Initialize the update object --- TODO = put interface
+    /* const update: any = {
+    modifiedAt: new Date(),
+  }; */
+    const update: any = {};
+
+    // Update name
+    if (args.name) {
+      const graphQLTypeName = Form.getGraphQLTypeName(args.name);
+      validateGraphQLTypeName(
+        Form.getGraphQLTypeName(args.name),
+        context.i18next
+      );
+      if (
+        (await Form.hasDuplicate(graphQLTypeName, form.id)) ||
+        (await ReferenceData.hasDuplicate(graphQLTypeName))
+      ) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.duplicatedGraphQLTypeName')
+        );
+      }
+      update.name = args.name;
+      update.graphQLTypeName = Form.getGraphQLTypeName(args.name);
+      if (form.core) {
+        await Resource.findByIdAndUpdate(form.resource, {
+          name: args.name,
+        });
+      }
+    }
+
+    // Update status
+    if (args.status) {
+      update.status = args.status;
+      // Activate the form.
+      if (update.status === status.active) {
+        // Create notification channel
+        const notificationChannel = new Channel({
+          title: `Form - ${form.name}`,
+          form: form._id,
+        });
+        await notificationChannel.save();
+        update.channel = notificationChannel.form;
+      } else {
+        // Deactivate the form
+        // delete channel and notifications if form not active anymore
+        const channel = await Channel.findOneAndDelete({ form: form._id });
+        if (channel) {
+          update.channel = [];
+        }
+      }
+    }
+
+    // Update permissions
+    if (args.permissions) {
+      const permissions: PermissionChange = args.permissions;
+      for (const permission in permissions) {
+        if (isArray(permissions[permission])) {
+          // if it's an array, replace the old value with the provided list
+          update['permissions.' + permission] = permissions[permission];
+        } else {
+          const obj = permissions[permission];
+          if (obj.add && obj.add.length) {
+            const pushRoles = {
+              [`permissions.${permission}`]: { $each: obj.add },
+            };
+
+            if (update.$addToSet) Object.assign(update.$addToSet, pushRoles);
+            else Object.assign(update, { $addToSet: pushRoles });
+          }
+          if (obj.remove && obj.remove.length) {
+            let pullRoles: any;
+
+            if (typeof obj.remove[0] === 'string') {
+              // CanSee, canUpdate, canDelete, canCreateRecords
+              pullRoles = {
+                [`permissions.${permission}`]: {
+                  $in: obj.remove.map(
+                    (role: any) => new mongoose.Types.ObjectId(role)
+                  ),
+                },
+              };
+            } else {
+              // canSeeRecords, canUpdateRecords, canDeleteRecords, recordsUnicity
+              pullRoles = {
+                [`permissions.${permission}`]: {
+                  $in: obj.remove.map((perm: any) =>
+                    perm.access
+                      ? {
+                          role: new mongoose.Types.ObjectId(perm.role),
+                          access: perm.access,
+                        }
+                      : {
+                          role: new mongoose.Types.ObjectId(perm.role),
+                        }
+                  ),
+                },
+              };
+            }
+
+            if (update.$pull) Object.assign(update.$pull, pullRoles);
+            else Object.assign(update, { $pull: pullRoles });
+          }
+        }
+      }
+    }
+
+    // Update fields and structure, check that structure is different
+    if (args.structure && !isEqual(form.structure, args.structure)) {
+      let alreadyUseField = false;
+      let usedFieldName;
+
+      // check field is already use in Layouts, Aggregations, Pull Job and widget
+      const formData = await Form.findById(args.id);
+      if (!!formData && !!formData.fields && formData.fields.length > 0) {
+        const resourceData = await Resource.findById(formData.resource);
+        if (
+          alreadyUseField == false &&
+          !!formData.resource &&
+          !!resourceData &&
+          !!resourceData.layouts &&
+          resourceData.layouts.length > 0
+        ) {
+          outerloop: for (let i = 0; i < formData.fields.length; i++) {
+            for (let j = 0; j < resourceData.layouts.length; j++) {
+              if (
+                !!resourceData.layouts[j].query &&
+                !!resourceData.layouts[j].query.fields &&
+                resourceData.layouts[j].query.fields.length > 0
+              ) {
+                for (
+                  let k = 0;
+                  k < resourceData.layouts[j].query.fields.length;
+                  k++
+                ) {
+                  if (
+                    resourceData.layouts[j].query.fields[k].name ===
+                    formData.fields[i].name
+                  ) {
+                    alreadyUseField = true;
+                    usedFieldName = 'layout';
+                    break outerloop;
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        if (
+          alreadyUseField == false &&
+          !!formData.resource &&
+          !!resourceData &&
+          !!resourceData.aggregations &&
+          resourceData.aggregations.length > 0
+        ) {
+          outerloop: for (let i = 0; i < formData.fields.length; i++) {
+            for (let j = 0; j < resourceData.aggregations.length; j++) {
+              if (
+                !!resourceData.aggregations[j].sourceFields &&
+                resourceData.aggregations[j].sourceFields.length > 0
+              ) {
+                for (
+                  let k = 0;
+                  k < resourceData.aggregations[j].sourceFields.length;
+                  k++
+                ) {
+                  if (
+                    resourceData.aggregations[j].sourceFields[k] ===
+                    formData.fields[i].name
+                  ) {
+                    alreadyUseField = true;
+                    usedFieldName = 'aggregation';
+                    break outerloop;
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        if (alreadyUseField == false) {
+          const pullJobData = await PullJob.findOne({ convertTo: args.id });
+          if (
+            !!pullJobData &&
+            !!pullJobData.mapping &&
+            Object.keys(pullJobData.mapping).length > 0
+          ) {
+            outerloop: for (let i = 0; i < formData.fields.length; i++) {
+              for (
+                let j = 0;
+                j < Object.keys(pullJobData.mapping).length;
+                j++
+              ) {
+                if (
+                  Object.keys(pullJobData.mapping)[j] ===
+                  formData.fields[i].name
+                ) {
+                  alreadyUseField = true;
+                  usedFieldName = 'pull job';
+                  break outerloop;
+                }
+              }
+            }
+          }
+        }
+      }
+      if (alreadyUseField) {
+        throw new GraphQLError(
+          context.i18next.t('mutations.form.edit.errors.alreadyUseFormField', {
+            name: usedFieldName,
+          })
+        );
+      }
+
+      update.structure = args.structure;
+      const structure = JSON.parse(args.structure);
+      const fields = [];
+      for (const page of structure.pages) {
+        await extractFields(page, fields, form.core);
+        findDuplicateFields(fields);
+        for (const field of fields.filter((x) =>
+          ['resource', 'resources'].includes(x.type)
+        )) {
+          // Raises an error if the field is already used as related name for this resource
+          if (
+            await Form.findOne({
+              fields: {
+                $elemMatch: {
+                  resource: field.resource,
+                  relatedName: field.relatedName,
+                },
+              },
+              _id: { $ne: form.id },
+              ...(form.resource && { resource: { $ne: form.resource } }),
+            })
+          ) {
+            throw new GraphQLError(
+              i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
+                name: field.relatedName,
+              })
+            );
+          }
+          // Raises an error if the field exists in the resource
+          if (
+            await Resource.findOne({
+              fields: { $elemMatch: { name: field.relatedName } },
+              _id: field.resource,
+            })
+          ) {
+            throw new GraphQLError(
+              i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
+                name: field.relatedName,
+              })
+            );
+          }
+        }
+      }
+      // === Resource inheritance management ===
+      const prevStructure = JSON.parse(form.structure ? form.structure : '{}'); // Get the current form's state structure
+      if (form.resource && !isEqual(prevStructure, structure)) {
+        // If the form has a resource and its structure has changed
+        const resource = await Resource.findById(form.resource);
+        const templates = await Form.find({
+          resource: form.resource,
+          _id: { $ne: mongoose.Types.ObjectId(args.id) },
+        }).select('_id structure fields');
+        const oldFields: any[] = JSON.parse(JSON.stringify(resource.fields));
+        const usedFields = templates
+          .map((x) => x.fields)
+          .flat()
+          .concat(fields);
+        // Check fields against the resource to add new ones or edit old ones
+        for (const field of fields) {
+          // For each field in the form being saved
+          const oldField = oldFields.find((x) => x.name === field.name); // Find the equivalent field in the resource's fields
+          if (!oldField) {
+            // If the field isn't found in the resource
+            const newField: any = Object.assign({}, field); // Create a copy of the form's field
+            newField.isRequired = form.core && field.isRequired ? true : false; // If it's a core form and the field isRequired, copy this property
+            oldFields.push(newField); // Add this field to the list of the resource's fields
+          } else {
+            // Check if field can be updated
+            if (!oldField.isCore || (oldField.isCore && form.core)) {
+              // If resource's field isn't core or if it's core but the edited form is core too, make it writable
+              const storedFieldChanged = !isEqual(oldField, field);
+              if (storedFieldChanged) {
+                // Inherit the field's permissions
+                field.permissions = oldField.permissions;
+                // If the resource's field and the current form's field are different
+                const index = oldFields.findIndex((x) => x.name === field.name); // Get the index of the form's field in the resources
+                oldFields.splice(index, 1, field); // Replace resource's field by the form's field
+              }
+              for (const template of templates) {
+                // For each form that inherits from the same resource
+                if (storedFieldChanged) {
+                  template.fields = template.fields.map((x) => {
+                    // For each field of the childForm
+                    return x.name === field.name // If the child field's name equals the parent field's name
+                      ? x.hasOwnProperty('defaultValue') &&
+                        !isEqual(x.defaultValue, oldField.defaultValue) // If the child possesses the "defaultValue" property
+                        ? { ...field, defaultValue: x.defaultValue } // Replace child's field by parent's field with child's field defaultValue's value
+                        : field // Else replace child's field by parent's field
+                      : x; // Else don't change the child's field
+                  });
+                }
+                if (!field.generated) {
+                  // Update structure
+                  const newStructure = JSON.parse(template.structure); // Get the inheriting form's structure
+                  replaceField(
+                    field.name,
+                    newStructure,
+                    structure,
+                    prevStructure
+                  ); // Replace the inheriting form's field by the edited form's field
+                  template.structure = JSON.stringify(newStructure); // Save the new structure
+                }
+              }
+            }
+          }
+        }
+        // Check if there are unused or duplicated fields in the resource
+        for (let index = 0; index < oldFields.length; index++) {
+          const field = oldFields[index]; // Store the resource's field
+          if (!field.isCalculated) {
+            // prevent calculated fields to be deleted automatically
+            const fieldToRemove =
+              ((form.core
+                ? !fields.some((x) => x.name === field.name)
+                : true) && // If edited form is core, check if resource's field is absent from form's fields
+                !usedFields.some((x) => x.name === field.name)) || // Unused -- TODO What if it's in one inherited form and not in another ?
+              oldFields.some((x, id) => field.name === x.name && id !== index); // Duplicated If there's another field with the same name but not the same ID
+            if (fieldToRemove) {
+              oldFields.splice(index, 1);
+              index--;
+            }
+          }
+        }
+        // Check if form is a core template of a resource
+        if (!form.core) {
+          // Check if a required field is missing
+          // Keep old version and move that to extract fields ?
+          let fieldExists = false;
+          for (const field of oldFields.filter((x) => x.isCore)) {
+            // For each non-core field in the resource
+            for (const x of fields) {
+              if (x.name === field.name) {
+                x.isCore = true;
+                fieldExists = true;
+              }
+            }
+            if (!fieldExists) {
+              throw new GraphQLError(
+                i18next.t('mutations.form.edit.errors.coreFieldMissing', {
+                  name: field.name,
+                })
+              );
+            }
+            fieldExists = false;
+          }
+        } else {
+          // List deleted fields
+          const deletedFields = form.fields.filter(
+            (x) => !fields.some((y) => x.name === y.name)
+          );
+          // List new fields
+          const newFields = fields.filter(
+            (x) => !form.fields.some((y) => x.name === y.name)
+          );
+          // Detect structure updates
+          const structureUpdate = {};
+          const newStructure = structure;
+          if (form.structure) {
+            // Store the property's objects that have been removed between the new and previous versions of the form
+            for (const property of INHERITED_PROPERTIES) {
+              if (!isEqual(prevStructure[property], newStructure[property])) {
+                structureUpdate[property] = newStructure[property]
+                  ? differenceWith(
+                      prevStructure[property],
+                      newStructure[property],
+                      isEqual
+                    )
+                  : prevStructure[property];
+              }
+            }
+          }
+
+          // Loop on templates
+          for (const template of templates) {
+            // === REFLECT DELETION ===
+            // For each old field from core form which is not anymore in the current core form fields
+            for (const field of deletedFields) {
+              // Check if we rename or delete a field used in a child form
+              if (usedFields.some((x) => x.name === field.name)) {
+                // If this deleted / modified field was used, reflect the deletion / edition
+                const index = template.fields.findIndex(
+                  (x) => x.name === field.name
+                );
+                template.fields.splice(index, 1);
+                if (!field.generated) {
+                  // Remove from structure
+                  const templateStructure = JSON.parse(template.structure);
+                  removeField(templateStructure, field.name);
+                  template.structure = JSON.stringify(templateStructure);
+                }
+              }
+            }
+
+            // === REFLECT ADDITION ===
+            // For each new field from core form which were not before in the old core form fields
+            for (const field of newFields) {
+              // Add to fields and structure if needed
+              if (!template.fields.some((x) => x.name === field.name)) {
+                template.fields.unshift(field);
+
+                if (!field.generated) {
+                  // Add to structure
+                  const templateStructure = JSON.parse(template.structure);
+                  addField(templateStructure, field.name, structure);
+                  template.structure = JSON.stringify(templateStructure);
+                }
+              }
+            }
+
+            // REFLECT STRUCTURE CHANGES ===
+            const templateStructure = JSON.parse(template.structure);
+            for (const objectKey in structureUpdate) {
+              // In a childForm's structure, if there are property's objects that have been deleted from the core form, delete them there too
+              if (
+                templateStructure[objectKey] &&
+                templateStructure[objectKey].length &&
+                structureUpdate[objectKey] &&
+                structureUpdate[objectKey].length
+              ) {
+                templateStructure[objectKey] = differenceWith(
+                  templateStructure[objectKey],
+                  structureUpdate[objectKey],
+                  isEqual
+                );
+              }
+              // Merge the new property's objects to the children
+              templateStructure[objectKey] = templateStructure[objectKey]
+                ? unionWith(
+                    templateStructure[objectKey],
+                    newStructure[objectKey],
+                    isEqual
+                  )
+                : newStructure[objectKey];
+              // If the property is null, undefined or empty, directly remove the entry from the structure
+              if (
+                !templateStructure[objectKey] ||
+                !templateStructure[objectKey].length
+              ) {
+                delete templateStructure[objectKey];
+              }
+            }
+            template.structure = JSON.stringify(templateStructure);
+          }
+
+          for (const field of deletedFields) {
+            // We remove the field from the resource
+            const index = oldFields.findIndex((x) => x.name === field.name);
+            if (index >= 0) {
+              oldFields.splice(index, 1);
+            }
+          }
+        }
+
+        // Build bulk update of non-core templates
+        const bulkUpdate = [];
+        for (const template of templates) {
+          bulkUpdate.push({
+            updateOne: {
+              filter: { _id: template._id },
+              update: {
+                structure: template.structure,
+                fields: template.fields,
+              },
+            },
+          });
+        }
+        if (bulkUpdate.length > 0) {
+          // Update all child form for addition/deletion/structure changes
+          await Form.bulkWrite(bulkUpdate);
+        }
+
+        // Update resource fields
+        await Resource.findByIdAndUpdate(form.resource, {
+          fields: oldFields,
+        });
+      }
+      update.fields = fields;
+      // Update version
+      const version = new Version({
+        //createdAt: form.modifiedAt ? form.modifiedAt : form.createdAt,
+        data: form.structure,
+      });
+      await version.save();
+      update.$push = { versions: version._id };
+    }
+    // Return updated form
+    return await Form.findByIdAndUpdate(args.id, update, { new: true }, () => {
+      // Avoid to rebuild types only if permissions changed
+      if (args.name || args.status || args.structure) {
+        buildTypes();
+      }
+    });
+    // } catch (err) {
+    //   logger.error(err.message, { stack: err.stack });
+    //   throw new GraphQLError(
+    //     context.i18next.t('common.errors.internalServerError')
+    //   );
+    // }
   },
 };

--- a/src/schema/mutation/editForm.mutation.ts
+++ b/src/schema/mutation/editForm.mutation.ts
@@ -32,7 +32,7 @@ import differenceWith from 'lodash/differenceWith';
 import unionWith from 'lodash/unionWith';
 import i18next from 'i18next';
 import { isArray } from 'lodash';
-// import { logger } from '@services/logger.service';
+import { logger } from '@services/logger.service';
 
 /**
  * List of keys of the structure's object which we want to inherit to the children forms when they are modified on the core form
@@ -87,630 +87,494 @@ export default {
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args, context) {
-    // try {
-    // Authentication check
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-
-    // Permission check
-    const ability: AppAbility = user.ability;
-    const form = await Form.findById(args.id);
-    if (ability.cannot('update', form)) {
-      throw new GraphQLError(
-        context.i18next.t('common.errors.permissionNotGranted')
-      );
-    }
-
-    // Initialize the update object --- TODO = put interface
-    /* const update: any = {
-    modifiedAt: new Date(),
-  }; */
-    const update: any = {};
-
-    // Update name
-    if (args.name) {
-      const graphQLTypeName = Form.getGraphQLTypeName(args.name);
-      validateGraphQLTypeName(
-        Form.getGraphQLTypeName(args.name),
-        context.i18next
-      );
-      if (
-        (await Form.hasDuplicate(graphQLTypeName, form.id)) ||
-        (await ReferenceData.hasDuplicate(graphQLTypeName))
-      ) {
+    try {
+      // Authentication check
+      const user = context.user;
+      if (!user) {
         throw new GraphQLError(
-          context.i18next.t('common.errors.duplicatedGraphQLTypeName')
+          context.i18next.t('common.errors.userNotLogged')
         );
       }
-      update.name = args.name;
-      update.graphQLTypeName = Form.getGraphQLTypeName(args.name);
-      if (form.core) {
-        await Resource.findByIdAndUpdate(form.resource, {
-          name: args.name,
-        });
+
+      // Permission check
+      const ability: AppAbility = user.ability;
+      const form = await Form.findById(args.id);
+
+      if (ability.cannot('update', form)) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
       }
-    }
 
-    // Update status
-    if (args.status) {
-      update.status = args.status;
-      // Activate the form.
-      if (update.status === status.active) {
-        // Create notification channel
-        const notificationChannel = new Channel({
-          title: `Form - ${form.name}`,
-          form: form._id,
-        });
-        await notificationChannel.save();
-        update.channel = notificationChannel.form;
-      } else {
-        // Deactivate the form
-        // delete channel and notifications if form not active anymore
-        const channel = await Channel.findOneAndDelete({ form: form._id });
-        if (channel) {
-          update.channel = [];
-        }
-      }
-    }
+      // Initialize the update object --- TODO = put interface
+      /* const update: any = {
+      modifiedAt: new Date(),
+    }; */
+      const update: any = {};
 
-    // Update permissions
-    if (args.permissions) {
-      const permissions: PermissionChange = args.permissions;
-      for (const permission in permissions) {
-        if (isArray(permissions[permission])) {
-          // if it's an array, replace the old value with the provided list
-          update['permissions.' + permission] = permissions[permission];
-        } else {
-          const obj = permissions[permission];
-          if (obj.add && obj.add.length) {
-            const pushRoles = {
-              [`permissions.${permission}`]: { $each: obj.add },
-            };
-
-            if (update.$addToSet) Object.assign(update.$addToSet, pushRoles);
-            else Object.assign(update, { $addToSet: pushRoles });
-          }
-          if (obj.remove && obj.remove.length) {
-            let pullRoles: any;
-
-            if (typeof obj.remove[0] === 'string') {
-              // CanSee, canUpdate, canDelete, canCreateRecords
-              pullRoles = {
-                [`permissions.${permission}`]: {
-                  $in: obj.remove.map(
-                    (role: any) => new mongoose.Types.ObjectId(role)
-                  ),
-                },
-              };
-            } else {
-              // canSeeRecords, canUpdateRecords, canDeleteRecords, recordsUnicity
-              pullRoles = {
-                [`permissions.${permission}`]: {
-                  $in: obj.remove.map((perm: any) =>
-                    perm.access
-                      ? {
-                          role: new mongoose.Types.ObjectId(perm.role),
-                          access: perm.access,
-                        }
-                      : {
-                          role: new mongoose.Types.ObjectId(perm.role),
-                        }
-                  ),
-                },
-              };
-            }
-
-            if (update.$pull) Object.assign(update.$pull, pullRoles);
-            else Object.assign(update, { $pull: pullRoles });
-          }
-        }
-      }
-    }
-
-    // Update fields and structure, check that structure is different
-    if (args.structure && !isEqual(form.structure, args.structure)) {
-      //get form data
-      const formData = await Form.findById(args.id);
-      if (!args.forceFullyUpdateFields) {
-        args.forceFullyUpdateFields = false;
-      }
-      //form data use or not and check forcefully update this form fields..
-      if (!!formData && args.forceFullyUpdateFields == false) {
-        let alreadyUseField = false;
-        let usedFieldName;
-
-        if (!!formData && !!formData.fields) {
-          //form fields are use or not in resource layout..
-          if (alreadyUseField == false) {
-            const resourceData = await Resource.findById(formData.resource);
-            if (
-              !!formData.resource &&
-              !!resourceData &&
-              !!resourceData.layouts
-            ) {
-              outerloop: for (let i = 0; i < formData.fields.length; i++) {
-                for (let j = 0; j < resourceData.layouts.length; j++) {
-                  if (
-                    !!resourceData.layouts[j].query &&
-                    !!resourceData.layouts[j].query.fields
-                  ) {
-                    for (
-                      let k = 0;
-                      k < resourceData.layouts[j].query.fields.length;
-                      k++
-                    ) {
-                      if (
-                        resourceData.layouts[j].query.fields[k].name ===
-                        formData.fields[i].name
-                      ) {
-                        alreadyUseField = true;
-                        usedFieldName = 'layout';
-                        break outerloop;
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-
-          //form fields are use or not in resource aggregation..
-          if (alreadyUseField == false) {
-            const resourceData = await Resource.findById(formData.resource);
-            if (
-              !!formData.resource &&
-              !!resourceData &&
-              !!resourceData.aggregations
-            ) {
-              outerloop: for (let i = 0; i < formData.fields.length; i++) {
-                for (let j = 0; j < resourceData.aggregations.length; j++) {
-                  if (!!resourceData.aggregations[j].sourceFields) {
-                    for (
-                      let k = 0;
-                      k < resourceData.aggregations[j].sourceFields.length;
-                      k++
-                    ) {
-                      if (
-                        resourceData.aggregations[j].sourceFields[k] ===
-                        formData.fields[i].name
-                      ) {
-                        alreadyUseField = true;
-                        usedFieldName = 'aggregation';
-                        break outerloop;
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-
-          //form fields are use or not in pull jobs..
-          if (alreadyUseField == false) {
-            const pullJobData = await PullJob.findOne({ convertTo: args.id });
-            if (!!pullJobData && !!pullJobData.mapping) {
-              outerloop: for (let i = 0; i < formData.fields.length; i++) {
-                for (
-                  let j = 0;
-                  j < Object.keys(pullJobData.mapping).length;
-                  j++
-                ) {
-                  if (
-                    Object.keys(pullJobData.mapping)[j] ===
-                    formData.fields[i].name
-                  ) {
-                    alreadyUseField = true;
-                    usedFieldName = 'pull job';
-                    break outerloop;
-                  }
-                }
-              }
-            }
-          }
-
-          //form fields are use or not in widget..
-          if (alreadyUseField == false) {
-            const widgetData = await Dashboard.find({
-              structure: {
-                $elemMatch: {
-                  'settings.resource': formData.resource.toString(),
-                },
-              },
-            });
-
-            if (!!widgetData) {
-              outerloop: for (let i = 0; i < formData.fields.length; i++) {
-                for (let j = 0; j < widgetData.length; j++) {
-                  for (let k = 0; k < widgetData[j].structure.length; k++) {
-                    const dashboardField =
-                      widgetData[j].structure[k].settings.query.fields;
-                    if (!!dashboardField) {
-                      for (let m = 0; m < dashboardField.length; m++) {
-                        if (
-                          dashboardField[m].name === formData.fields[i].name
-                        ) {
-                          alreadyUseField = true;
-                          usedFieldName = 'widget';
-                          break outerloop;
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        if (alreadyUseField) {
-          // If use form field in layout / aggregation / pull jobs / widget than showing popup
+      // Update name
+      if (args.name) {
+        const graphQLTypeName = Form.getGraphQLTypeName(args.name);
+        validateGraphQLTypeName(
+          Form.getGraphQLTypeName(args.name),
+          context.i18next
+        );
+        if (
+          (await Form.hasDuplicate(graphQLTypeName, form.id)) ||
+          (await ReferenceData.hasDuplicate(graphQLTypeName))
+        ) {
           throw new GraphQLError(
-            context.i18next.t(
-              'mutations.form.edit.errors.alreadyUseFormField',
-              {
-                name: usedFieldName,
-              }
-            )
+            context.i18next.t('common.errors.duplicatedGraphQLTypeName')
           );
         }
+        update.name = args.name;
+        update.graphQLTypeName = Form.getGraphQLTypeName(args.name);
+        if (form.core) {
+          await Resource.findByIdAndUpdate(form.resource, {
+            name: args.name,
+          });
+        }
       }
 
-      update.structure = args.structure;
-      const structure = JSON.parse(args.structure);
-      const fields = [];
-      for (const page of structure.pages) {
-        await extractFields(page, fields, form.core);
-        findDuplicateFields(fields);
-        for (const field of fields.filter((x) =>
-          ['resource', 'resources'].includes(x.type)
-        )) {
-          // Raises an error if the field is already used as related name for this resource
-          if (
-            await Form.findOne({
-              fields: {
-                $elemMatch: {
-                  resource: field.resource,
-                  relatedName: field.relatedName,
-                },
-              },
-              _id: { $ne: form.id },
-              ...(form.resource && { resource: { $ne: form.resource } }),
-            })
-          ) {
-            throw new GraphQLError(
-              i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
-                name: field.relatedName,
-              })
-            );
-          }
-          // Raises an error if the field exists in the resource
-          if (
-            await Resource.findOne({
-              fields: { $elemMatch: { name: field.relatedName } },
-              _id: field.resource,
-            })
-          ) {
-            throw new GraphQLError(
-              i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
-                name: field.relatedName,
-              })
-            );
+      // Update status
+      if (args.status) {
+        update.status = args.status;
+        // Activate the form.
+        if (update.status === status.active) {
+          // Create notification channel
+          const notificationChannel = new Channel({
+            title: `Form - ${form.name}`,
+            form: form._id,
+          });
+          await notificationChannel.save();
+          update.channel = notificationChannel.form;
+        } else {
+          // Deactivate the form
+          // delete channel and notifications if form not active anymore
+          const channel = await Channel.findOneAndDelete({ form: form._id });
+          if (channel) {
+            update.channel = [];
           }
         }
       }
-      // === Resource inheritance management ===
-      const prevStructure = JSON.parse(form.structure ? form.structure : '{}'); // Get the current form's state structure
-      if (form.resource && !isEqual(prevStructure, structure)) {
-        // If the form has a resource and its structure has changed
-        const resource = await Resource.findById(form.resource);
-        const templates = await Form.find({
-          resource: form.resource,
-          _id: { $ne: mongoose.Types.ObjectId(args.id) },
-        }).select('_id structure fields');
-        const oldFields: any[] = JSON.parse(JSON.stringify(resource.fields));
-        const usedFields = templates
-          .map((x) => x.fields)
-          .flat()
-          .concat(fields);
-        // Check fields against the resource to add new ones or edit old ones
-        for (const field of fields) {
-          // For each field in the form being saved
-          const oldField = oldFields.find((x) => x.name === field.name); // Find the equivalent field in the resource's fields
-          if (!oldField) {
-            // If the field isn't found in the resource
-            const newField: any = Object.assign({}, field); // Create a copy of the form's field
-            newField.isRequired = form.core && field.isRequired ? true : false; // If it's a core form and the field isRequired, copy this property
-            oldFields.push(newField); // Add this field to the list of the resource's fields
+
+      // Update permissions
+      if (args.permissions) {
+        const permissions: PermissionChange = args.permissions;
+        for (const permission in permissions) {
+          if (isArray(permissions[permission])) {
+            // if it's an array, replace the old value with the provided list
+            update['permissions.' + permission] = permissions[permission];
           } else {
-            // Check if field can be updated
-            if (!oldField.isCore || (oldField.isCore && form.core)) {
-              // If resource's field isn't core or if it's core but the edited form is core too, make it writable
-              const storedFieldChanged = !isEqual(oldField, field);
-              if (storedFieldChanged) {
-                // Inherit the field's permissions
-                field.permissions = oldField.permissions;
-                // If the resource's field and the current form's field are different
-                const index = oldFields.findIndex((x) => x.name === field.name); // Get the index of the form's field in the resources
-                oldFields.splice(index, 1, field); // Replace resource's field by the form's field
+            const obj = permissions[permission];
+            if (obj.add && obj.add.length) {
+              const pushRoles = {
+                [`permissions.${permission}`]: { $each: obj.add },
+              };
+
+              if (update.$addToSet) Object.assign(update.$addToSet, pushRoles);
+              else Object.assign(update, { $addToSet: pushRoles });
+            }
+            if (obj.remove && obj.remove.length) {
+              let pullRoles: any;
+
+              if (typeof obj.remove[0] === 'string') {
+                // CanSee, canUpdate, canDelete, canCreateRecords
+                pullRoles = {
+                  [`permissions.${permission}`]: {
+                    $in: obj.remove.map(
+                      (role: any) => new mongoose.Types.ObjectId(role)
+                    ),
+                  },
+                };
+              } else {
+                // canSeeRecords, canUpdateRecords, canDeleteRecords, recordsUnicity
+                pullRoles = {
+                  [`permissions.${permission}`]: {
+                    $in: obj.remove.map((perm: any) =>
+                      perm.access
+                        ? {
+                            role: new mongoose.Types.ObjectId(perm.role),
+                            access: perm.access,
+                          }
+                        : {
+                            role: new mongoose.Types.ObjectId(perm.role),
+                          }
+                    ),
+                  },
+                };
               }
-              for (const template of templates) {
-                // For each form that inherits from the same resource
-                if (storedFieldChanged) {
-                  template.fields = template.fields.map((x) => {
-                    // For each field of the childForm
-                    return x.name === field.name // If the child field's name equals the parent field's name
-                      ? x.hasOwnProperty('defaultValue') &&
-                        !isEqual(x.defaultValue, oldField.defaultValue) // If the child possesses the "defaultValue" property
-                        ? { ...field, defaultValue: x.defaultValue } // Replace child's field by parent's field with child's field defaultValue's value
-                        : field // Else replace child's field by parent's field
-                      : x; // Else don't change the child's field
-                  });
-                }
-                if (!field.generated) {
-                  // Update structure
-                  const newStructure = JSON.parse(template.structure); // Get the inheriting form's structure
-                  replaceField(
-                    field.name,
-                    newStructure,
-                    structure,
-                    prevStructure
-                  ); // Replace the inheriting form's field by the edited form's field
-                  template.structure = JSON.stringify(newStructure); // Save the new structure
-                }
-              }
+
+              if (update.$pull) Object.assign(update.$pull, pullRoles);
+              else Object.assign(update, { $pull: pullRoles });
             }
           }
         }
-        // Check if there are unused or duplicated fields in the resource
-        for (let index = 0; index < oldFields.length; index++) {
-          const field = oldFields[index]; // Store the resource's field
-          if (!field.isCalculated) {
-            // prevent calculated fields to be deleted automatically
-            const fieldToRemove =
-              ((form.core
-                ? !fields.some((x) => x.name === field.name)
-                : true) && // If edited form is core, check if resource's field is absent from form's fields
-                !usedFields.some((x) => x.name === field.name)) || // Unused -- TODO What if it's in one inherited form and not in another ?
-              oldFields.some((x, id) => field.name === x.name && id !== index); // Duplicated If there's another field with the same name but not the same ID
-            if (fieldToRemove) {
-              oldFields.splice(index, 1);
-              index--;
-            }
-          }
-        }
-        // Check if form is a core template of a resource
-        if (!form.core) {
-          // Check if a required field is missing
-          // Keep old version and move that to extract fields ?
-          let fieldExists = false;
-          for (const field of oldFields.filter((x) => x.isCore)) {
-            // For each non-core field in the resource
-            for (const x of fields) {
-              if (x.name === field.name) {
-                x.isCore = true;
-                fieldExists = true;
-              }
-            }
-            if (!fieldExists) {
+      }
+
+      // Update fields and structure, check that structure is different
+      if (args.structure && !isEqual(form.structure, args.structure)) {
+        update.structure = args.structure;
+        const structure = JSON.parse(args.structure);
+        const fields = [];
+        for (const page of structure.pages) {
+          await extractFields(page, fields, form.core);
+          findDuplicateFields(fields);
+          for (const field of fields.filter((x) =>
+            ['resource', 'resources'].includes(x.type)
+          )) {
+            // Raises an error if the field is already used as related name for this resource
+            if (
+              await Form.findOne({
+                fields: {
+                  $elemMatch: {
+                    resource: field.resource,
+                    relatedName: field.relatedName,
+                  },
+                },
+                _id: { $ne: form.id },
+                ...(form.resource && { resource: { $ne: form.resource } }),
+              })
+            ) {
               throw new GraphQLError(
-                i18next.t('mutations.form.edit.errors.coreFieldMissing', {
-                  name: field.name,
+                i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
+                  name: field.relatedName,
                 })
               );
             }
-            fieldExists = false;
+            // Raises an error if the field exists in the resource
+            if (
+              await Resource.findOne({
+                fields: { $elemMatch: { name: field.relatedName } },
+                _id: field.resource,
+              })
+            ) {
+              throw new GraphQLError(
+                i18next.t('mutations.form.edit.errors.relatedNameDuplicated', {
+                  name: field.relatedName,
+                })
+              );
+            }
           }
-        } else {
-          // List deleted fields
-          const deletedFields = form.fields.filter(
-            (x) => !fields.some((y) => x.name === y.name)
-          );
-          // List new fields
-          const newFields = fields.filter(
-            (x) => !form.fields.some((y) => x.name === y.name)
-          );
-          // Detect structure updates
-          const structureUpdate = {};
-          const newStructure = structure;
-          if (form.structure) {
-            // Store the property's objects that have been removed between the new and previous versions of the form
-            for (const property of INHERITED_PROPERTIES) {
-              if (!isEqual(prevStructure[property], newStructure[property])) {
-                structureUpdate[property] = newStructure[property]
-                  ? differenceWith(
-                      prevStructure[property],
-                      newStructure[property],
+        }
+        // === Resource inheritance management ===
+        const prevStructure = JSON.parse(
+          form.structure ? form.structure : '{}'
+        ); // Get the current form's state structure
+        if (form.resource && !isEqual(prevStructure, structure)) {
+          // If the form has a resource and its structure has changed
+          const resource = await Resource.findById(form.resource);
+          const templates = await Form.find({
+            resource: form.resource,
+            _id: { $ne: mongoose.Types.ObjectId(args.id) },
+          }).select('_id structure fields');
+          const oldFields: any[] = JSON.parse(JSON.stringify(resource.fields));
+          const usedFields = templates
+            .map((x) => x.fields)
+            .flat()
+            .concat(fields);
+          // Check fields against the resource to add new ones or edit old ones
+          for (const field of fields) {
+            // For each field in the form being saved
+            const oldField = oldFields.find((x) => x.name === field.name); // Find the equivalent field in the resource's fields
+            if (!oldField) {
+              // If the field isn't found in the resource
+              const newField: any = Object.assign({}, field); // Create a copy of the form's field
+              newField.isRequired =
+                form.core && field.isRequired ? true : false; // If it's a core form and the field isRequired, copy this property
+              oldFields.push(newField); // Add this field to the list of the resource's fields
+            } else {
+              // Check if field can be updated
+              if (!oldField.isCore || (oldField.isCore && form.core)) {
+                // If resource's field isn't core or if it's core but the edited form is core too, make it writable
+                const storedFieldChanged = !isEqual(oldField, field);
+                if (storedFieldChanged) {
+                  // Inherit the field's permissions
+                  field.permissions = oldField.permissions;
+                  // If the resource's field and the current form's field are different
+                  const index = oldFields.findIndex(
+                    (x) => x.name === field.name
+                  ); // Get the index of the form's field in the resources
+                  oldFields.splice(index, 1, field); // Replace resource's field by the form's field
+                }
+                for (const template of templates) {
+                  // For each form that inherits from the same resource
+                  if (storedFieldChanged) {
+                    template.fields = template.fields.map((x) => {
+                      // For each field of the childForm
+                      return x.name === field.name // If the child field's name equals the parent field's name
+                        ? x.hasOwnProperty('defaultValue') &&
+                          !isEqual(x.defaultValue, oldField.defaultValue) // If the child possesses the "defaultValue" property
+                          ? { ...field, defaultValue: x.defaultValue } // Replace child's field by parent's field with child's field defaultValue's value
+                          : field // Else replace child's field by parent's field
+                        : x; // Else don't change the child's field
+                    });
+                  }
+                  if (!field.generated) {
+                    // Update structure
+                    const newStructure = JSON.parse(template.structure); // Get the inheriting form's structure
+                    replaceField(
+                      field.name,
+                      newStructure,
+                      structure,
+                      prevStructure
+                    ); // Replace the inheriting form's field by the edited form's field
+                    template.structure = JSON.stringify(newStructure); // Save the new structure
+                  }
+                }
+              }
+            }
+          }
+          // Check if there are unused or duplicated fields in the resource
+          for (let index = 0; index < oldFields.length; index++) {
+            const field = oldFields[index]; // Store the resource's field
+            if (!field.isCalculated) {
+              // prevent calculated fields to be deleted automatically
+              const fieldToRemove =
+                ((form.core
+                  ? !fields.some((x) => x.name === field.name)
+                  : true) && // If edited form is core, check if resource's field is absent from form's fields
+                  !usedFields.some((x) => x.name === field.name)) || // Unused -- TODO What if it's in one inherited form and not in another ?
+                oldFields.some(
+                  (x, id) => field.name === x.name && id !== index
+                ); // Duplicated If there's another field with the same name but not the same ID
+              if (fieldToRemove) {
+                oldFields.splice(index, 1);
+                index--;
+              }
+            }
+          }
+          // Check if form is a core template of a resource
+          if (!form.core) {
+            // Check if a required field is missing
+            // Keep old version and move that to extract fields ?
+            let fieldExists = false;
+            for (const field of oldFields.filter((x) => x.isCore)) {
+              // For each non-core field in the resource
+              for (const x of fields) {
+                if (x.name === field.name) {
+                  x.isCore = true;
+                  fieldExists = true;
+                }
+              }
+              if (!fieldExists) {
+                throw new GraphQLError(
+                  i18next.t('mutations.form.edit.errors.coreFieldMissing', {
+                    name: field.name,
+                  })
+                );
+              }
+              fieldExists = false;
+            }
+          } else {
+            // List deleted fields
+            const deletedFields = form.fields.filter(
+              (x) => !fields.some((y) => x.name === y.name)
+            );
+            // List new fields
+            const newFields = fields.filter(
+              (x) => !form.fields.some((y) => x.name === y.name)
+            );
+            // Detect structure updates
+            const structureUpdate = {};
+            const newStructure = structure;
+            if (form.structure) {
+              // Store the property's objects that have been removed between the new and previous versions of the form
+              for (const property of INHERITED_PROPERTIES) {
+                if (!isEqual(prevStructure[property], newStructure[property])) {
+                  structureUpdate[property] = newStructure[property]
+                    ? differenceWith(
+                        prevStructure[property],
+                        newStructure[property],
+                        isEqual
+                      )
+                    : prevStructure[property];
+                }
+              }
+            }
+
+            // Loop on templates
+            for (const template of templates) {
+              // === REFLECT DELETION ===
+              // For each old field from core form which is not anymore in the current core form fields
+              for (const field of deletedFields) {
+                // Check if we rename or delete a field used in a child form
+                if (usedFields.some((x) => x.name === field.name)) {
+                  // If this deleted / modified field was used, reflect the deletion / edition
+                  const index = template.fields.findIndex(
+                    (x) => x.name === field.name
+                  );
+                  template.fields.splice(index, 1);
+                  if (!field.generated) {
+                    // Remove from structure
+                    const templateStructure = JSON.parse(template.structure);
+                    removeField(templateStructure, field.name);
+                    template.structure = JSON.stringify(templateStructure);
+                  }
+                }
+              }
+
+              // === REFLECT ADDITION ===
+              // For each new field from core form which were not before in the old core form fields
+              for (const field of newFields) {
+                // Add to fields and structure if needed
+                if (!template.fields.some((x) => x.name === field.name)) {
+                  template.fields.unshift(field);
+
+                  if (!field.generated) {
+                    // Add to structure
+                    const templateStructure = JSON.parse(template.structure);
+                    addField(templateStructure, field.name, structure);
+                    template.structure = JSON.stringify(templateStructure);
+                  }
+                }
+              }
+
+              // REFLECT STRUCTURE CHANGES ===
+              const templateStructure = JSON.parse(template.structure);
+              for (const objectKey in structureUpdate) {
+                // In a childForm's structure, if there are property's objects that have been deleted from the core form, delete them there too
+                if (
+                  templateStructure[objectKey] &&
+                  templateStructure[objectKey].length &&
+                  structureUpdate[objectKey] &&
+                  structureUpdate[objectKey].length
+                ) {
+                  templateStructure[objectKey] = differenceWith(
+                    templateStructure[objectKey],
+                    structureUpdate[objectKey],
+                    isEqual
+                  );
+                }
+                // Merge the new property's objects to the children
+                templateStructure[objectKey] = templateStructure[objectKey]
+                  ? unionWith(
+                      templateStructure[objectKey],
+                      newStructure[objectKey],
                       isEqual
                     )
-                  : prevStructure[property];
+                  : newStructure[objectKey];
+                // If the property is null, undefined or empty, directly remove the entry from the structure
+                if (
+                  !templateStructure[objectKey] ||
+                  !templateStructure[objectKey].length
+                ) {
+                  delete templateStructure[objectKey];
+                }
               }
+              template.structure = JSON.stringify(templateStructure);
             }
-          }
 
-          // Loop on templates
-          for (const template of templates) {
-            // === REFLECT DELETION ===
-            // For each old field from core form which is not anymore in the current core form fields
             for (const field of deletedFields) {
-              // Check if we rename or delete a field used in a child form
-              if (usedFields.some((x) => x.name === field.name)) {
-                // If this deleted / modified field was used, reflect the deletion / edition
-                const index = template.fields.findIndex(
-                  (x) => x.name === field.name
-                );
-                template.fields.splice(index, 1);
-                if (!field.generated) {
-                  // Remove from structure
-                  const templateStructure = JSON.parse(template.structure);
-                  removeField(templateStructure, field.name);
-                  template.structure = JSON.stringify(templateStructure);
-                }
+              // We remove the field from the resource
+              const index = oldFields.findIndex((x) => x.name === field.name);
+              if (index >= 0) {
+                oldFields.splice(index, 1);
               }
             }
-
-            // === REFLECT ADDITION ===
-            // For each new field from core form which were not before in the old core form fields
-            for (const field of newFields) {
-              // Add to fields and structure if needed
-              if (!template.fields.some((x) => x.name === field.name)) {
-                template.fields.unshift(field);
-
-                if (!field.generated) {
-                  // Add to structure
-                  const templateStructure = JSON.parse(template.structure);
-                  addField(templateStructure, field.name, structure);
-                  template.structure = JSON.stringify(templateStructure);
-                }
-              }
-            }
-
-            // REFLECT STRUCTURE CHANGES ===
-            const templateStructure = JSON.parse(template.structure);
-            for (const objectKey in structureUpdate) {
-              // In a childForm's structure, if there are property's objects that have been deleted from the core form, delete them there too
-              if (
-                templateStructure[objectKey] &&
-                templateStructure[objectKey].length &&
-                structureUpdate[objectKey] &&
-                structureUpdate[objectKey].length
-              ) {
-                templateStructure[objectKey] = differenceWith(
-                  templateStructure[objectKey],
-                  structureUpdate[objectKey],
-                  isEqual
-                );
-              }
-              // Merge the new property's objects to the children
-              templateStructure[objectKey] = templateStructure[objectKey]
-                ? unionWith(
-                    templateStructure[objectKey],
-                    newStructure[objectKey],
-                    isEqual
-                  )
-                : newStructure[objectKey];
-              // If the property is null, undefined or empty, directly remove the entry from the structure
-              if (
-                !templateStructure[objectKey] ||
-                !templateStructure[objectKey].length
-              ) {
-                delete templateStructure[objectKey];
-              }
-            }
-            template.structure = JSON.stringify(templateStructure);
-          }
-
-          for (const field of deletedFields) {
-            // We remove the field from the resource
-            const index = oldFields.findIndex((x) => x.name === field.name);
-            if (index >= 0) {
-              oldFields.splice(index, 1);
-            }
-          }
-          if (!!formData && !!formData.resource) {
-            const resourceData = await Resource.findById(formData.resource);
-            if (!!resourceData && !!resourceData.layouts) {
-              deletedFields.map(async function (items) {
-                const layoutData = [];
-                resourceData.layouts.map(async function (result) {
-                  if (!!result.query && !!result.query.fields) {
-                    const layoutFields = [];
-                    result.query.fields.map(async function (layout) {
-                      if (items.name !== layout.name) {
-                        layoutFields.push(layout);
-                      }
-                    });
-                    result.query.fields = layoutFields;
-                    layoutData.push(result);
-                  }
-                });
-                await Resource.updateOne(
-                  {
-                    _id: formData.resource,
-                  },
-                  {
-                    $set: {
-                      layouts: layoutData,
+            if (!!form && !!form.resource) {
+              const resourceData = await Resource.findById(form.resource);
+              if (!!resourceData && !!resourceData.layouts) {
+                deletedFields.map(async function (items) {
+                  const layoutData = [];
+                  resourceData.layouts.map(async function (result) {
+                    if (!!result.query && !!result.query.fields) {
+                      const layoutFields = [];
+                      result.query.fields.map(async function (layout) {
+                        if (items.name !== layout.name) {
+                          layoutFields.push(layout);
+                        }
+                      });
+                      result.query.fields = layoutFields;
+                      layoutData.push(result);
+                    }
+                  });
+                  await Resource.updateOne(
+                    {
+                      _id: form.resource,
                     },
-                  }
-                );
-              });
-            }
-            if (!!resourceData && !!resourceData.aggregations) {
-              deletedFields.map(async function (items) {
-                const aggregationData = [];
-                resourceData.aggregations.map(async function (result) {
-                  if (!!result.sourceFields && !!result.sourceFields) {
-                    const aggregationFields = [];
-                    result.sourceFields.map(async function (aggregation) {
-                      if (items.name !== aggregation) {
-                        aggregationFields.push(aggregation);
-                      }
-                    });
-                    result.sourceFields = aggregationFields;
-                    aggregationData.push(result);
-                  }
+                    {
+                      $set: {
+                        layouts: layoutData,
+                      },
+                    }
+                  );
                 });
-                await Resource.updateOne(
-                  {
-                    _id: formData.resource,
-                  },
-                  {
-                    $set: {
-                      aggregations: aggregationData,
+              }
+              if (!!resourceData && !!resourceData.aggregations) {
+                deletedFields.map(async function (items) {
+                  const aggregationData = [];
+                  resourceData.aggregations.map(async function (result) {
+                    if (!!result.sourceFields && !!result.sourceFields) {
+                      const aggregationFields = [];
+                      result.sourceFields.map(async function (aggregation) {
+                        if (items.name !== aggregation) {
+                          aggregationFields.push(aggregation);
+                        }
+                      });
+                      result.sourceFields = aggregationFields;
+                      aggregationData.push(result);
+                    }
+                  });
+                  await Resource.updateOne(
+                    {
+                      _id: form.resource,
                     },
-                  }
-                );
-              });
+                    {
+                      $set: {
+                        aggregations: aggregationData,
+                      },
+                    }
+                  );
+                });
+              }
             }
           }
-        }
 
-        // Build bulk update of non-core templates
-        const bulkUpdate = [];
-        for (const template of templates) {
-          bulkUpdate.push({
-            updateOne: {
-              filter: { _id: template._id },
-              update: {
-                structure: template.structure,
-                fields: template.fields,
+          // Build bulk update of non-core templates
+          const bulkUpdate = [];
+          for (const template of templates) {
+            bulkUpdate.push({
+              updateOne: {
+                filter: { _id: template._id },
+                update: {
+                  structure: template.structure,
+                  fields: template.fields,
+                },
               },
-            },
+            });
+          }
+          if (bulkUpdate.length > 0) {
+            // Update all child form for addition/deletion/structure changes
+            await Form.bulkWrite(bulkUpdate);
+          }
+
+          // Update resource fields
+          await Resource.findByIdAndUpdate(form.resource, {
+            fields: oldFields,
           });
         }
-        if (bulkUpdate.length > 0) {
-          // Update all child form for addition/deletion/structure changes
-          await Form.bulkWrite(bulkUpdate);
-        }
-
-        // Update resource fields
-        await Resource.findByIdAndUpdate(form.resource, {
-          fields: oldFields,
+        update.fields = fields;
+        // Update version
+        const version = new Version({
+          //createdAt: form.modifiedAt ? form.modifiedAt : form.createdAt,
+          data: form.structure,
         });
+        await version.save();
+        update.$push = { versions: version._id };
       }
-      update.fields = fields;
-      // Update version
-      const version = new Version({
-        //createdAt: form.modifiedAt ? form.modifiedAt : form.createdAt,
-        data: form.structure,
+      // Return updated form
+      return Form.findByIdAndUpdate(args.id, update, { new: true }, () => {
+        // Avoid to rebuild types only if permissions changed
+        if (args.name || args.status || args.structure) {
+          buildTypes();
+        }
       });
-      await version.save();
-      update.$push = { versions: version._id };
+    } catch (err) {
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-    // Return updated form
-    return Form.findByIdAndUpdate(args.id, update, { new: true }, () => {
-      // Avoid to rebuild types only if permissions changed
-      if (args.name || args.status || args.structure) {
-        buildTypes();
-      }
-    });
-    // } catch (err) {
-    //   logger.error(err.message, { stack: err.stack });
-    //   throw new GraphQLError(
-    //     context.i18next.t('common.errors.internalServerError')
-    //   );
-    // }
   },
 };

--- a/src/schema/mutation/editLayout.mutation.ts
+++ b/src/schema/mutation/editLayout.mutation.ts
@@ -43,6 +43,7 @@ export default {
       if (!args.forceFullyUpdateFields) {
         args.forceFullyUpdateFields = false;
       }
+
       //check layout data available or not and check forcefully update this layout fields..
       if (
         !!resourceData &&
@@ -51,50 +52,31 @@ export default {
       ) {
         //get widget data
         const widgetData = await Dashboard.find({
-          structure: {
-            $elemMatch: { 'settings.resource': resourceData._id },
-          },
+          $and: [
+            {
+              structure: {
+                $elemMatch: {
+                  'settings.resource': resourceData._id.toString(),
+                },
+              },
+            },
+            {
+              structure: {
+                $elemMatch: { 'settings.layouts': args.id.toString() },
+              },
+            },
+          ],
         });
 
-        //check widget data available or not.
         if (!!widgetData) {
-          //layout field are use or not in widget..
-          for (
-            let i = 0;
-            i < resourceData.layouts[0].sourceFields.length;
-            i++
-          ) {
-            for (let j = 0; j < widgetData.length; j++) {
-              if (!!widgetData[j].structure) {
-                for (let k = 0; k < widgetData[j].structure.length; k++) {
-                  if (
-                    !!widgetData[j].structure[k].settings &&
-                    !!widgetData[j].structure[k].settings.query &&
-                    !!widgetData[j].structure[k].settings.query.fields
-                  ) {
-                    const dashboardField =
-                      widgetData[j].structure[k].settings.query.fields;
-                    for (let m = 0; m < dashboardField.length; m++) {
-                      if (
-                        dashboardField[m].name ===
-                        resourceData.layouts[0].sourceFields[i]
-                      ) {
-                        // If use aggregation field in widget than showing popup
-                        throw new GraphQLError(
-                          context.i18next.t(
-                            'mutations.form.edit.errors.alreadyUseFormField',
-                            {
-                              name: 'widget',
-                            }
-                          )
-                        );
-                      }
-                    }
-                  }
-                }
+          throw new GraphQLError(
+            context.i18next.t(
+              'mutations.layout.edit.errors.alreadyUseLayoutField',
+              {
+                name: 'widget',
               }
-            }
-          }
+            )
+          );
         }
       }
       const filters = Resource.accessibleBy(ability, 'update')

--- a/src/schema/mutation/editLayout.mutation.ts
+++ b/src/schema/mutation/editLayout.mutation.ts
@@ -1,9 +1,9 @@
 import { GraphQLError, GraphQLID, GraphQLNonNull } from 'graphql';
-import { Resource, Form } from '@models';
+import { Resource, Form, Dashboard } from '@models';
 import { LayoutType } from '../../schema/types';
 import { AppAbility } from '@security/defineUserAbility';
 import LayoutInputType from '../../schema/inputs/layout.input';
-import { logger } from '@services/logger.service';
+// import { logger } from '@services/logger.service';
 
 /**
  * Edits an existing layout.
@@ -17,59 +17,122 @@ export default {
     form: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    try {
-      if (args.form && args.resource) {
-        throw new GraphQLError(
-          context.i18next.t(
-            'mutations.layout.edit.errors.invalidAddPageArguments'
-          )
-        );
-      }
-      const user = context.user;
-      if (!user) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.userNotLogged')
-        );
-      }
-      const ability: AppAbility = user.ability;
-      // Edition of a resource
-      if (args.resource) {
-        const filters = Resource.accessibleBy(ability, 'update')
-          .where({ _id: args.resource })
-          .getFilter();
-        const resource: Resource = await Resource.findOne(filters);
-        if (!resource) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.permissionNotGranted')
-          );
-        }
-        resource.layouts.id(args.id).name = args.layout.name;
-        resource.layouts.id(args.id).query = args.layout.query;
-        resource.layouts.id(args.id).display = args.layout.display;
-        await resource.save();
-        return resource.layouts.id(args.id);
-      } else {
-        // Edition of a Form
-        const filters = Form.accessibleBy(ability, 'update')
-          .where({ _id: args.form })
-          .getFilter();
-        const form: Form = await Form.findOne(filters);
-        if (!form) {
-          throw new GraphQLError(
-            context.i18next.t('common.errors.permissionNotGranted')
-          );
-        }
-        form.layouts.id(args.id).name = args.layout.name;
-        form.layouts.id(args.id).query = args.layout.query;
-        form.layouts.id(args.id).display = args.layout.display;
-        await form.save();
-        return form.layouts.id(args.id);
-      }
-    } catch (err) {
-      logger.error(err.message, { stack: err.stack });
+    // try {
+    if (args.form && args.resource) {
       throw new GraphQLError(
-        context.i18next.t('common.errors.internalServerError')
+        context.i18next.t(
+          'mutations.layout.edit.errors.invalidAddPageArguments'
+        )
       );
     }
+    const user = context.user;
+    if (!user) {
+      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
+    }
+
+    const ability: AppAbility = user.ability;
+    // Edition of a resource
+    if (args.resource) {
+      //get resource layout data
+      const resourceData = await Resource.findOne({
+        layouts: {
+          $elemMatch: { _id: args.id },
+        },
+      });
+
+      if (!args.forceFullyUpdateFields) {
+        args.forceFullyUpdateFields = false;
+      }
+      //check layout data available or not and check forcefully update this layout fields..
+      if (
+        !!resourceData &&
+        !!resourceData.layouts &&
+        args.forceFullyUpdateFields == false
+      ) {
+        //get widget data
+        const widgetData = await Dashboard.find({
+          structure: {
+            $elemMatch: { 'settings.resource': resourceData._id },
+          },
+        });
+
+        //check widget data available or not.
+        if (!!widgetData) {
+          //layout field are use or not in widget..
+          for (
+            let i = 0;
+            i < resourceData.layouts[0].sourceFields.length;
+            i++
+          ) {
+            for (let j = 0; j < widgetData.length; j++) {
+              if (!!widgetData[j].structure) {
+                for (let k = 0; k < widgetData[j].structure.length; k++) {
+                  if (
+                    !!widgetData[j].structure[k].settings &&
+                    !!widgetData[j].structure[k].settings.query &&
+                    !!widgetData[j].structure[k].settings.query.fields
+                  ) {
+                    const dashboardField =
+                      widgetData[j].structure[k].settings.query.fields;
+                    for (let m = 0; m < dashboardField.length; m++) {
+                      if (
+                        dashboardField[m].name ===
+                        resourceData.layouts[0].sourceFields[i]
+                      ) {
+                        // If use aggregation field in widget than showing popup
+                        throw new GraphQLError(
+                          context.i18next.t(
+                            'mutations.form.edit.errors.alreadyUseFormField',
+                            {
+                              name: 'widget',
+                            }
+                          )
+                        );
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      const filters = Resource.accessibleBy(ability, 'update')
+        .where({ _id: args.resource })
+        .getFilter();
+      const resource: Resource = await Resource.findOne(filters);
+      if (!resource) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      resource.layouts.id(args.id).name = args.layout.name;
+      resource.layouts.id(args.id).query = args.layout.query;
+      resource.layouts.id(args.id).display = args.layout.display;
+      await resource.save();
+      return resource.layouts.id(args.id);
+    } else {
+      // Edition of a Form
+      const filters = Form.accessibleBy(ability, 'update')
+        .where({ _id: args.form })
+        .getFilter();
+      const form: Form = await Form.findOne(filters);
+      if (!form) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+      form.layouts.id(args.id).name = args.layout.name;
+      form.layouts.id(args.id).query = args.layout.query;
+      form.layouts.id(args.id).display = args.layout.display;
+      await form.save();
+      return form.layouts.id(args.id);
+    }
+    // } catch (err) {
+    //   logger.error(err.message, { stack: err.stack });
+    //   throw new GraphQLError(
+    //     context.i18next.t('common.errors.internalServerError')
+    //   );
+    // }
   },
 };

--- a/src/schema/mutation/editLayout.mutation.ts
+++ b/src/schema/mutation/editLayout.mutation.ts
@@ -1,9 +1,9 @@
 import { GraphQLError, GraphQLID, GraphQLNonNull } from 'graphql';
-import { Resource, Form, Dashboard } from '@models';
+import { Resource, Form } from '@models';
 import { LayoutType } from '../../schema/types';
 import { AppAbility } from '@security/defineUserAbility';
 import LayoutInputType from '../../schema/inputs/layout.input';
-// import { logger } from '@services/logger.service';
+import { logger } from '@services/logger.service';
 
 /**
  * Edits an existing layout.
@@ -17,104 +17,60 @@ export default {
     form: { type: GraphQLID },
   },
   async resolve(parent, args, context) {
-    // try {
-    if (args.form && args.resource) {
-      throw new GraphQLError(
-        context.i18next.t(
-          'mutations.layout.edit.errors.invalidAddPageArguments'
-        )
-      );
-    }
-    const user = context.user;
-    if (!user) {
-      throw new GraphQLError(context.i18next.t('common.errors.userNotLogged'));
-    }
-
-    const ability: AppAbility = user.ability;
-    // Edition of a resource
-    if (args.resource) {
-      //get resource layout data
-      const resourceData = await Resource.findOne({
-        layouts: {
-          $elemMatch: { _id: args.id },
-        },
-      });
-
-      if (!args.forceFullyUpdateFields) {
-        args.forceFullyUpdateFields = false;
+    try {
+      if (args.form && args.resource) {
+        throw new GraphQLError(
+          context.i18next.t(
+            'mutations.layout.edit.errors.invalidAddPageArguments'
+          )
+        );
+      }
+      const user = context.user;
+      if (!user) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.userNotLogged')
+        );
       }
 
-      //check layout data available or not and check forcefully update this layout fields..
-      if (
-        !!resourceData &&
-        !!resourceData.layouts &&
-        args.forceFullyUpdateFields == false
-      ) {
-        //get widget data
-        const widgetData = await Dashboard.find({
-          $and: [
-            {
-              structure: {
-                $elemMatch: {
-                  'settings.resource': resourceData._id.toString(),
-                },
-              },
-            },
-            {
-              structure: {
-                $elemMatch: { 'settings.layouts': args.id.toString() },
-              },
-            },
-          ],
-        });
-
-        if (!!widgetData) {
+      const ability: AppAbility = user.ability;
+      // Edition of a resource
+      if (args.resource) {
+        const filters = Resource.accessibleBy(ability, 'update')
+          .where({ _id: args.resource })
+          .getFilter();
+        const resource: Resource = await Resource.findOne(filters);
+        if (!resource) {
           throw new GraphQLError(
-            context.i18next.t(
-              'mutations.layout.edit.errors.alreadyUseLayoutField',
-              {
-                name: 'widget',
-              }
-            )
+            context.i18next.t('common.errors.permissionNotGranted')
           );
         }
+        resource.layouts.id(args.id).name = args.layout.name;
+        resource.layouts.id(args.id).query = args.layout.query;
+        resource.layouts.id(args.id).display = args.layout.display;
+        await resource.save();
+        return resource.layouts.id(args.id);
+      } else {
+        // Edition of a Form
+        const filters = Form.accessibleBy(ability, 'update')
+          .where({ _id: args.form })
+          .getFilter();
+        const form: Form = await Form.findOne(filters);
+        if (!form) {
+          throw new GraphQLError(
+            context.i18next.t('common.errors.permissionNotGranted')
+          );
+        }
+        form.layouts.id(args.id).name = args.layout.name;
+        form.layouts.id(args.id).query = args.layout.query;
+        form.layouts.id(args.id).display = args.layout.display;
+        await form.save();
+        return form.layouts.id(args.id);
       }
-      const filters = Resource.accessibleBy(ability, 'update')
-        .where({ _id: args.resource })
-        .getFilter();
-      const resource: Resource = await Resource.findOne(filters);
-      if (!resource) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-      resource.layouts.id(args.id).name = args.layout.name;
-      resource.layouts.id(args.id).query = args.layout.query;
-      resource.layouts.id(args.id).display = args.layout.display;
-      await resource.save();
-      return resource.layouts.id(args.id);
-    } else {
-      // Edition of a Form
-      const filters = Form.accessibleBy(ability, 'update')
-        .where({ _id: args.form })
-        .getFilter();
-      const form: Form = await Form.findOne(filters);
-      if (!form) {
-        throw new GraphQLError(
-          context.i18next.t('common.errors.permissionNotGranted')
-        );
-      }
-      form.layouts.id(args.id).name = args.layout.name;
-      form.layouts.id(args.id).query = args.layout.query;
-      form.layouts.id(args.id).display = args.layout.display;
-      await form.save();
-      return form.layouts.id(args.id);
+    } catch (err) {
+      logger.error(err.message, { stack: err.stack });
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
     }
-    // } catch (err) {
-    //   logger.error(err.message, { stack: err.stack });
-    //   throw new GraphQLError(
-    //     context.i18next.t('common.errors.internalServerError')
-    //   );
-    // }
   },
 };


### PR DESCRIPTION
# Description
When editing forms / resources, we could indicate to users if the form / resource is used by any of these items:
- layout
- aggregation
- widget
- pull job
Same for the fields of the forms / resources. When trying to save the form, we could indicate to the user that the field is actually used by some items in the platform, and it may lead to an issue

## Ticket
https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/11064

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

