### PR TITLE
Fix/ab#57979 check read only mode for field is working when updating record

### DIFF
--- a/src/routes/gis/index.ts
+++ b/src/routes/gis/index.ts
@@ -12,7 +12,6 @@ import turf, { booleanPointInPolygon } from '@turf/turf';
 /**
  * Interface of feature query
  */
-
 interface IFeatureQuery {
   geoField?: string;
   longitudeField?: string;

--- a/src/routes/gis/index.ts
+++ b/src/routes/gis/index.ts
@@ -27,6 +27,12 @@ interface IFeatureQuery {
  */
 const router = express.Router();
 
+/**
+ * Get filter of polygon
+ *
+ * @param query lat long
+ * @returns return polygon
+ */
 const getFilterPolygon = (query: IFeatureQuery) => {
   if (
     !isNil(query.minLat) &&
@@ -188,7 +194,7 @@ router.get('/feature', async (req, res) => {
       const layouts = resourceData.layouts || [];
       const layout = layouts.find((x) => isEqual(x._id, id));
 
-      const filterPolygon = getFilterPolygon(req.query);
+      getFilterPolygon(req.query);
 
       if (aggregation) {
         query = `query recordsAggregation($resource: ID!, $aggregation: ID!) {

--- a/src/routes/gis/index.ts
+++ b/src/routes/gis/index.ts
@@ -12,6 +12,7 @@ import turf, { booleanPointInPolygon } from '@turf/turf';
 /**
  * Interface of feature query
  */
+
 interface IFeatureQuery {
   geoField?: string;
   longitudeField?: string;

--- a/src/schema/mutation/editRecord.mutation.ts
+++ b/src/schema/mutation/editRecord.mutation.ts
@@ -93,6 +93,15 @@ export default {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')
         );
+      } else {
+        //When the readOnly property of a field is true, the permission to update the records is granted.Than this fields are remove in data parameter.
+        parentForm.fields.map(function (result) {
+          Object.keys(args.data).map(function (items) {
+            if (result.readOnly && result.name == items) {
+              delete args.data[items];
+            }
+          });
+        });
       }
 
       // Update record

--- a/src/schema/mutation/editRecord.mutation.ts
+++ b/src/schema/mutation/editRecord.mutation.ts
@@ -94,7 +94,7 @@ export default {
           context.i18next.t('common.errors.permissionNotGranted')
         );
       } else {
-        //When the readOnly property of a field is true, the permission to update the records is granted.Than this fields are remove in data parameter.
+        //When the readOnly property of a field is true, the permission to update the records is granted.Than this fields are remove in data parameter
         parentForm.fields.map(function (result) {
           Object.keys(args.data).map(function (items) {
             if (result.readOnly && result.name == items) {

--- a/src/security/extendAbilityForRecords.ts
+++ b/src/security/extendAbilityForRecords.ts
@@ -33,6 +33,13 @@ function userCanAccessField(
   if (field === undefined) return false;
   const arrayToCheck = type === 'read' ? 'canSee' : 'canUpdate';
 
+  //If the redOnly property of the field is true, ignore the permission check to update the records
+  if (arrayToCheck === 'canUpdate') {
+    if (field.readOnly) {
+      return false;
+    }
+  }
+
   // if the user has a role in the array, they should have the permission, return true
   // otherwise, return false
   return user.roles?.some((role: Role) =>


### PR DESCRIPTION
# Description
Some questions have the readOnly option
when building permissions, if you have the ability to update any field of any resource , then you would see that you can write on the field, even if you should not

## Ticket
https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/57979

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

