### PR TITLE
fix/AB#74954_prevent-duplicate-contextualized-pages

### DIFF
--- a/src/models/page.model.ts
+++ b/src/models/page.model.ts
@@ -161,7 +161,7 @@ pageSchema.pre('save', async function (next) {
   const uniqueRecords = new Set();
 
   for (const entry of this.contentWithContext) {
-    // Add the element and record to the unique sets
+    /** Add the element and record to the unique sets */
     if ('element' in entry && entry.element) {
       uniqueElements.add(entry.element.toString());
     }
@@ -170,17 +170,19 @@ pageSchema.pre('save', async function (next) {
     }
   }
 
-  // Check if the sets have the same size as the array
-  // If not, there are duplicates
+  /**
+   * Check if the sets have the same size as the array
+   * If not, there are duplicates
+   */
   if (
     uniqueElements.size !== this.contentWithContext.length &&
     uniqueRecords.size !== this.contentWithContext.length
   ) {
     const newContentWithContext = [];
 
-    // Iterate through contentWithContext array
+    /** Iterate through contentWithContext array */
     for (const entry of this.contentWithContext) {
-      // Add the element and record to the unique sets
+      /** Add the element and record to the unique sets */
       if ('element' in entry && entry.element) {
         if (uniqueElements.has(entry.element.toString())) {
           newContentWithContext.push(entry);
@@ -194,12 +196,12 @@ pageSchema.pre('save', async function (next) {
         }
       }
     }
-    // We don't save the last element because it'll be saved when we call next()
+    /** We don't save the last element because it'll be saved when we call next() */
     newContentWithContext.pop();
     await this.updateOne({ contentWithContext: newContentWithContext });
   }
-
-  next(); // Continue saving
+  /** Continue saving */
+  next();
 });
 
 pageSchema.plugin(accessibleRecordsPlugin);

--- a/src/models/page.model.ts
+++ b/src/models/page.model.ts
@@ -152,6 +152,56 @@ addOnBeforeDeleteMany(pageSchema, async (pages) => {
   );
 });
 
+/**
+ * Checks if the contentWithContext array contains duplicates before saving
+ * If so, we only keep the first occurrence of the duplicate
+ */
+pageSchema.pre('save', async function (next) {
+  const uniqueElements = new Set();
+  const uniqueRecords = new Set();
+
+  for (const entry of this.contentWithContext) {
+    // Add the element and record to the unique sets
+    if ('element' in entry && entry.element) {
+      uniqueElements.add(entry.element.toString());
+    }
+    if ('record' in entry && entry.record) {
+      uniqueRecords.add(entry.record.toString());
+    }
+  }
+
+  // Check if the sets have the same size as the array
+  // If not, there are duplicates
+  if (
+    uniqueElements.size !== this.contentWithContext.length &&
+    uniqueRecords.size !== this.contentWithContext.length
+  ) {
+    const newContentWithContext = [];
+
+    // Iterate through contentWithContext array
+    for (const entry of this.contentWithContext) {
+      // Add the element and record to the unique sets
+      if ('element' in entry && entry.element) {
+        if (uniqueElements.has(entry.element.toString())) {
+          newContentWithContext.push(entry);
+          uniqueElements.delete(entry.element.toString());
+        }
+      }
+      if ('record' in entry && entry.record) {
+        if (uniqueRecords.has(entry.record.toString())) {
+          newContentWithContext.push(entry);
+          uniqueRecords.delete(entry.record.toString());
+        }
+      }
+    }
+    // We don't save the last element because it'll be saved when we call next()
+    newContentWithContext.pop();
+    await this.updateOne({ contentWithContext: newContentWithContext });
+  }
+
+  next(); // Continue saving
+});
+
 pageSchema.plugin(accessibleRecordsPlugin);
 
 /** Mongoose page model definition */


### PR DESCRIPTION
# Description

This PR makes it so it's impossible add duplicate contextualized pages (from same record/element) by adding a middleware check in the page schema

Note: this approach let's us not worry about creating a migration to delete the duplicates

## Useful links

- Please insert link to ticket https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/74954
- Frontend PR: https://github.com/ReliefApplications/oort-frontend/pull/1825

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] By forcing the frontend to send the same mutation twice that created the dashboards 
- [x] By creating a dashboard in a page that already have duplicates

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
