### PR TITLE
Feat/ab#69019 allow user with read permission duplicate applications and page

### DIFF
--- a/src/schema/mutation/duplicateApplication.mutation.ts
+++ b/src/schema/mutation/duplicateApplication.mutation.ts
@@ -29,7 +29,7 @@ export default {
       const user = context.user;
 
       const ability: AppAbility = context.user.ability;
-      if (ability.can('create', 'Application')) {
+      if (ability.can('read', 'Application')) {
         const baseApplication = await Application.findById(args.application);
         const copiedPages = await duplicatePages(baseApplication);
         if (!baseApplication)

--- a/src/schema/mutation/duplicatePage.mutation.ts
+++ b/src/schema/mutation/duplicatePage.mutation.ts
@@ -44,7 +44,7 @@ export default {
       if (!application)
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
       // Check access to the application
-      if (ability.can('update', application)) {
+      if (ability.can('read', application)) {
         if (args.page) {
           // If page
           const page = await Page.findById(args.page);


### PR DESCRIPTION
# Description

Allowed users with read permission duplicate pages and applications instead of only with update permissions

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/69019)
[frontend](https://github.com/ReliefApplications/oort-frontend/pull/1930)

## Type of change

- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

It has been tested verifying if users with read permission can now duplicate pages and applications.

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
