### PR TITLE
AB#78096 - ability to hide vertical menu by default

### DIFF
--- a/src/models/application.model.ts
+++ b/src/models/application.model.ts
@@ -25,6 +25,7 @@ export interface Application extends Document {
   modifiedAt: Date;
   description?: string;
   sideMenu?: boolean;
+  showLeftSideBar?: boolean;
   status?: any;
   createdBy?: mongoose.Types.ObjectId;
   pages?: (mongoose.Types.ObjectId | Page)[];
@@ -73,6 +74,7 @@ const applicationSchema = new Schema<Application>(
     settings: mongoose.Schema.Types.Mixed,
     description: String,
     sideMenu: Boolean,
+    showLeftSideBar: Boolean,
     permissions: {
       canSee: [
         {

--- a/src/schema/mutation/editApplication.mutation.ts
+++ b/src/schema/mutation/editApplication.mutation.ts
@@ -26,6 +26,7 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
     description: { type: GraphQLString },
     sideMenu: { type: GraphQLBoolean },
+    showLeftSideBar: { type: GraphQLBoolean },
     name: { type: GraphQLString },
     status: { type: StatusEnumType },
     pages: { type: new GraphQLList(GraphQLID) },
@@ -84,7 +85,10 @@ export default {
         args.contextualFilterPosition && {
           contextualFilterPosition: args.contextualFilterPosition,
         },
-        !isNil(args.sideMenu) && { sideMenu: args.sideMenu }
+        !isNil(args.sideMenu) && { sideMenu: args.sideMenu },
+        !isNil(args.showLeftSideBar) && {
+          showLeftSideBar: args.showLeftSideBar,
+        }
       );
       application = await Application.findOneAndUpdate(filters, update, {
         new: true,

--- a/src/schema/types/application.type.ts
+++ b/src/schema/types/application.type.ts
@@ -65,6 +65,17 @@ export const ApplicationType = new GraphQLObjectType({
         }
       },
     },
+    showLeftSideBar: {
+      type: GraphQLBoolean,
+      resolve(parent) {
+        // Default to true
+        if (isNil(parent.showLeftSideBar)) {
+          return true;
+        } else {
+          return parent.showLeftSideBar;
+        }
+      },
+    },
     status: { type: StatusEnumType },
     locked: {
       type: GraphQLBoolean,


### PR DESCRIPTION
# Description

Back-end part of the PoC for hiding vertical menu by default. Basically adds an attribute to the app to save the users preference on this matter

## Useful links

- [ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/78096)
- Link to front-end PR : https://github.com/ReliefApplications/oort-frontend/pull/1953

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested directly in the app with both new and old apps

## Screenshots

![274600373-322db091-768d-4b67-a217-3765603a6ae1](https://github.com/ReliefApplications/oort-backend/assets/103029022/e32ed9b8-5f18-47ae-92cd-143dfd1f49fc)
![274600466-6b83fe06-2170-4be9-a949-bd360a11dae6](https://github.com/ReliefApplications/oort-backend/assets/103029022/43a230f2-1fd6-4776-ab27-095909fbc4cf)


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
