### PR TITLE
HIT-fix/HIT-112_simplyfy-staff-record-unicity

### DIFF
--- a/src/schema/types/form.type.ts
+++ b/src/schema/types/form.type.ts
@@ -209,8 +209,7 @@ export const FormType = new GraphQLObjectType({
         const user = context.user;
         if (
           parent.permissions.recordsUnicity &&
-          parent.permissions.recordsUnicity.length > 0 &&
-          parent.permissions.recordsUnicity[0].role
+          parent.permissions.recordsUnicity.length > 0
         ) {
           const unicityFilters = getFormPermissionFilter(
             user,

--- a/src/utils/alimentaide/onStructureAdded.ts
+++ b/src/utils/alimentaide/onStructureAdded.ts
@@ -1,13 +1,5 @@
 import { Types } from 'mongoose';
-import {
-  Application,
-  Page,
-  Resource,
-  Role,
-  Record,
-  Form,
-  Channel,
-} from '@models';
+import { Application, Page, Resource, Role, Record, Channel } from '@models';
 import { duplicatePage } from '@services/page.service';
 import { copyFolder } from '@utils/files/copyFolder';
 
@@ -16,9 +8,6 @@ const BASE_APP_ID = new Types.ObjectId('64dec0ab3fb2a1f0738dfa85');
 
 /** The ID of the worker user */
 const WORKER_ID = new Types.ObjectId('651b61b82313350f9e79c772');
-
-/** The ID of the Staff from */
-const STAFF_FORM_ID = new Types.ObjectId('649e9ec5eae9f845cd921f01');
 
 /** The ID for the super admin role */
 const SUPER_ADMIN_ROLE_ID = new Types.ObjectId('64934ecc859314002ab554aa');
@@ -373,28 +362,6 @@ const onStructureAdded = async (rec: Record) => {
       }
     });
   }
-
-  // Maintain record unicity in the Staff form
-  const staffForm = await Form.findById(STAFF_FORM_ID);
-  staffForm.permissions.recordsUnicity.push(
-    ...rolesToAdd.map((r) => ({
-      role: r._id,
-      access: {
-        logic: 'and',
-        filters: [
-          {
-            field: 'linked_user',
-            operator: 'eq',
-            value: ['me'],
-          },
-        ],
-      },
-    }))
-  );
-
-  // Save the staff form
-  staffForm.markModified('permissions');
-  await staffForm.save();
 
   // Save the resources
   await Promise.all(resources.map((r) => r.save()));


### PR DESCRIPTION
# Description

This PR simplifies the logic with the record unicity for the Staff form. We no longer need to set roles alongside the access filters to have it working. This also means we no longer need to add 3 new rules for each new structure/application.

## Useful links

- [Please insert link to ticket](https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=HIT-112)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By loading the profile form on a account that has answered it before

## Screenshots
![Peek 2023-08-30 03-01](https://github.com/ReliefApplications/ems-backend/assets/102038450/495bd3ae-e25d-4071-8f73-6e13ce01d213)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
