### PR TITLE
fix/HIT-131-add-check-if-date-exist-for-calculated-fields

### DIFF
--- a/src/utils/aggregation/buildCalculatedFieldPipeline.ts
+++ b/src/utils/aggregation/buildCalculatedFieldPipeline.ts
@@ -156,19 +156,11 @@ const resolveSingleOperator = (
       {
         $addFields: {
           [path.startsWith('aux.') ? path : `data.${path}`]: {
-            $getField: {
-              field: operation,
-              input: {
-                $dateToParts: {
-                  date: {
-                    $dateFromString: {
-                      dateString: getValueString(),
-                      onError: null,
-                      onNull: null,
-                    },
-                  },
-                  timezone: timeZone,
-                },
+            [operationMap[operation]]: {
+              $dateFromString: {
+                dateString: getValueString(),
+                onError: null,
+                onNull: null,
               },
             },
           },

--- a/src/utils/aggregation/buildCalculatedFieldPipeline.ts
+++ b/src/utils/aggregation/buildCalculatedFieldPipeline.ts
@@ -148,7 +148,13 @@ const resolveSingleOperator = (
       {
         $addFields: {
           [path.startsWith('aux.') ? path : `data.${path}`]: {
-            [operationMap[operation]]: getValueString(),
+            [operationMap[operation]]: {
+              $dateFromString: {
+                dateString: getValueString(),
+                onError: null,
+                onNull: null,
+              },
+            },
           },
         },
       }

--- a/src/utils/aggregation/buildCalculatedFieldPipeline.ts
+++ b/src/utils/aggregation/buildCalculatedFieldPipeline.ts
@@ -141,20 +141,14 @@ const resolveSingleOperator = (
     });
     return `$${auxPath.startsWith('aux.') ? '' : 'aux.'}${auxPath}`;
   };
-  const step = ['exists', 'size', 'date', 'toLong', 'toInt', 'length'].includes(
+  const step = ['exists', 'size', 'toLong', 'toInt', 'length'].includes(
     operation
   )
     ? // Simple operations
       {
         $addFields: {
           [path.startsWith('aux.') ? path : `data.${path}`]: {
-            [operationMap[operation]]: {
-              $dateFromString: {
-                dateString: getValueString(),
-                onError: null,
-                onNull: null,
-              },
-            },
+            [operationMap[operation]]: getValueString(),
           },
         },
       }
@@ -167,7 +161,11 @@ const resolveSingleOperator = (
               input: {
                 $dateToParts: {
                   date: {
-                    $toDate: getValueString(),
+                    $dateFromString: {
+                      dateString: getValueString(),
+                      onError: null,
+                      onNull: null,
+                    },
                   },
                   timezone: timeZone,
                 },


### PR DESCRIPTION
# Description

Added a step which catches errors when trying to parse non-date strings into dates.

## Useful links

- https://oortcloud.atlassian.net/jira/software/projects/HIT/boards/5?selectedIssue=HIT-131

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Creating a calculated field containing a string such as "" and trying to display it as a date in a grid would break the grid layout and show no records available. Now it correctly shows empty.

## Screenshots

![image](https://github.com/ReliefApplications/ems-backend/assets/39497117/da3c083a-c467-43cd-8de6-bee55247b6eb)

# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings