### PR TITLE
fix/AB#71363_inconsistency-in-field-permission

### DIFF
--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -698,6 +698,17 @@ export default {
               obj.remove.role,
               permission
             );
+
+            // If we remove the canSee of a field, we should remove the canUpdate as well
+            if (permission === 'canSee') {
+              removeFieldPermission(
+                update,
+                allResourceFields,
+                obj.remove.field,
+                obj.remove.role,
+                'canUpdate'
+              );
+            }
           }
         }
       }

--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -699,6 +699,17 @@ export default {
               obj.remove.role,
               permission
             );
+
+            // If we remove the canSee of a field, we should remove the canUpdate as well
+            if (permission === 'canSee') {
+              removeFieldPermission(
+                update,
+                allResourceFields,
+                obj.remove.field,
+                obj.remove.role,
+                'canUpdate'
+              );
+            }
           }
         }
       }


### PR DESCRIPTION
# Description

This PR changes the editResource mutation so that if we toggle off the a field's canSee permission, it'll automatically remove the canUpdate, if it exists

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/71363
- Please insert link to front-end branch if any: https://github.com/ReliefApplications/ems-frontend/pull/2014

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

See bellow 

## Screenshots
![Peek 2023-08-30 03-01](https://github.com/ReliefApplications/ems-backend/assets/102038450/a7266972-e153-41f9-877c-eaf27d93d5ea)



# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
