### PR TITLE
feat/HIT-134_Change-NextStepOnSave-Logic

### DIFF
--- a/src/models/step.model.ts
+++ b/src/models/step.model.ts
@@ -12,6 +12,7 @@ export interface Step extends Document {
   icon: string;
   createdAt: Date;
   modifiedAt: Date;
+  nextStepOnSave: boolean;
   type: string;
   content: any;
   permissions: {
@@ -31,6 +32,7 @@ const stepSchema = new Schema<Step>(
   {
     name: String,
     icon: String,
+    nextStepOnSave: Boolean,
     type: {
       type: String,
       enum: Object.values(contentType),

--- a/src/models/workflow.model.ts
+++ b/src/models/workflow.model.ts
@@ -11,7 +11,6 @@ export interface Workflow extends Document {
   createdAt: Date;
   modifiedAt: Date;
   steps: any[];
-  nextStepOnSave: boolean;
   archived: boolean;
   archivedAt?: Date;
 }
@@ -24,7 +23,6 @@ const workflowSchema = new Schema<Workflow>(
       type: [mongoose.Schema.Types.ObjectId],
       ref: 'Step',
     },
-    nextStepOnSave: Boolean,
     archived: {
       type: Boolean,
       default: false,

--- a/src/schema/mutation/editStep.mutation.ts
+++ b/src/schema/mutation/editStep.mutation.ts
@@ -3,6 +3,7 @@ import {
   GraphQLID,
   GraphQLString,
   GraphQLError,
+  GraphQLBoolean,
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
 import { cloneDeep, isArray, isEmpty, omit } from 'lodash';
@@ -38,6 +39,7 @@ type EditStepArgs = {
   content?: string | Types.ObjectId;
   permissions?: any;
   icon?: string;
+  nextStepOnSave?: boolean;
 };
 
 /**
@@ -52,6 +54,7 @@ export default {
     icon: { type: GraphQLString },
     type: { type: GraphQLString },
     content: { type: GraphQLID },
+    nextStepOnSave: { type: GraphQLBoolean },
     permissions: { type: GraphQLJSON },
   },
   async resolve(parent, args: EditStepArgs, context: Context) {
@@ -101,6 +104,9 @@ export default {
         ...(args.icon && { icon: args.icon }),
         ...(args.type && { type: args.type }),
         ...(args.content && { content: args.content }),
+        ...(args.nextStepOnSave !== undefined && {
+          nextStepOnSave: args.nextStepOnSave,
+        }),
       };
       // Updating permissions
       const permissionsUpdate: any = {};

--- a/src/schema/mutation/editStep.mutation.ts
+++ b/src/schema/mutation/editStep.mutation.ts
@@ -6,7 +6,7 @@ import {
   GraphQLBoolean,
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
-import { cloneDeep, isArray, isEmpty, omit } from 'lodash';
+import { cloneDeep, isArray, isEmpty, isNil, omit } from 'lodash';
 import { contentType } from '@const/enumTypes';
 import { StepType } from '../types';
 import { Dashboard, Form, Step } from '@models';
@@ -104,7 +104,7 @@ export default {
         ...(args.icon && { icon: args.icon }),
         ...(args.type && { type: args.type }),
         ...(args.content && { content: args.content }),
-        ...(args.nextStepOnSave !== undefined && {
+        ...(!isNil(args.nextStepOnSave) && {
           nextStepOnSave: args.nextStepOnSave,
         }),
       };

--- a/src/schema/types/step.type.ts
+++ b/src/schema/types/step.type.ts
@@ -23,6 +23,7 @@ export const StepType = new GraphQLObjectType({
     },
     name: { type: GraphQLString },
     icon: { type: GraphQLString },
+    nextStepOnSave: { type: GraphQLBoolean },
     createdAt: { type: GraphQLString },
     modifiedAt: { type: GraphQLString },
     type: { type: ContentEnumType },

--- a/src/schema/types/workflow.type.ts
+++ b/src/schema/types/workflow.type.ts
@@ -20,7 +20,6 @@ export const WorkflowType = new GraphQLObjectType({
     name: { type: GraphQLString },
     createdAt: { type: GraphQLString },
     modifiedAt: { type: GraphQLString },
-    nextStepOnSave: { type: GraphQLBoolean },
     steps: {
       type: new GraphQLList(StepType),
       async resolve(parent: Workflow, args, context) {

--- a/src/services/page.service.ts
+++ b/src/services/page.service.ts
@@ -86,7 +86,6 @@ const duplicateContent = async (
         name: name || w.name,
         createdAt: new Date(),
         steps,
-        nextStepOnSave: !!w.nextStepOnSave,
       });
       await workflow.save();
       content = workflow._id;


### PR DESCRIPTION
# Description

Previously, this configuration could only be done through the database within the workflow model. When you have a form within a workflow followed by another page, saving the form would automatically advance you to the next page. To provide greater control over this process, I added an option in the step model. You can access this option through the step configuration modal, located in the General tab.

## Useful links

- Please insert link to ticket: https://oortcloud.atlassian.net/jira/software/projects/OORT/boards/5?selectedIssue=HIT-134
- Please insert link to front-end branch if any: https://github.com/ReliefApplications/ems-frontend/pull/2010

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Enabling next step on save and checking if it works.

## Screenshots

Added screenshot in front-end branch.

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
