### PR TITLE
feat/AB#72596_Not-all-of-the-updated-record-information-is-available-in-Exported-History-file-of-record

### DIFF
--- a/src/utils/history/recordHistory.ts
+++ b/src/utils/history/recordHistory.ts
@@ -322,13 +322,19 @@ export class RecordHistory {
         (!current || current[key] === null || current[key] === undefined) &&
         after[key]
       ) {
-        changes.push({
-          type: 'add',
-          displayType: this.options.translate('history.value.add'),
-          displayName: this.getDisplayName(key),
-          field: key,
-          new: after[key],
-        });
+        if (
+          !changes.find(
+            (change) => change.field === key && change.new === after[key]
+          )
+        ) {
+          changes.push({
+            type: 'add',
+            displayType: this.options.translate('history.value.add'),
+            displayName: this.getDisplayName(key),
+            field: key,
+            new: after[key],
+          });
+        }
       }
     });
     return changes;


### PR DESCRIPTION
# Description

Before having an empty field in a grid and filling data in it would save the history log twice
Now it checks that the change is not in the array

## Useful links

- [Llink to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/72596)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots



# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
