### PR TITLE
feat/AB#78304-sort-on-multiple-fields-in-aggregation

### DIFF
--- a/src/utils/aggregation/buildPipeline.ts
+++ b/src/utils/aggregation/buildPipeline.ts
@@ -58,23 +58,24 @@ const buildPipeline = (
         break;
       }
       case PipelineStage.SORT: {
-        const sortStage = pipeline.find((element: any) =>
-          Object.keys(element).includes('$sort')
-        );
-        if (sortStage) {
-          // Join all sort criteria to add a single sort stage with all fields with criteria and not multiple sort stages
-          // (necessary for sort on multiple fields to work)
-          sortStage.$sort = {
-            ...sortStage.$sort,
-            [stage.form.field]: stage.form.order === 'asc' ? 1 : -1,
-          };
-        } else {
-          pipeline.push({
-            $sort: {
+        // Try to group sort stages together ( when they are following )
+        if (pipeline.length > 0) {
+          const previousStage = pipeline[pipeline.length - 1];
+          if (Object.keys(previousStage)[0] === '$sort') {
+            // Join with previous sort criteria to add a single sort stage with all fields with criteria and not multiple sort stages
+            // (necessary for sort on multiple fields to work)
+            previousStage.$sort = {
+              ...previousStage.$sort,
               [stage.form.field]: stage.form.order === 'asc' ? 1 : -1,
-            },
-          });
+            };
+            break;
+          }
         }
+        pipeline.push({
+          $sort: {
+            [stage.form.field]: stage.form.order === 'asc' ? 1 : -1,
+          },
+        });
         break;
       }
       case PipelineStage.GROUP: {

--- a/src/utils/aggregation/buildPipeline.ts
+++ b/src/utils/aggregation/buildPipeline.ts
@@ -58,11 +58,23 @@ const buildPipeline = (
         break;
       }
       case PipelineStage.SORT: {
-        pipeline.push({
-          $sort: {
+        const sortStage = pipeline.find((element: any) =>
+          Object.keys(element).includes('$sort')
+        );
+        if (sortStage) {
+          // Join all sort criteria to add a single sort stage with all fields with criteria and not multiple sort stages
+          // (necessary for sort on multiple fields to work)
+          sortStage.$sort = {
+            ...sortStage.$sort,
             [stage.form.field]: stage.form.order === 'asc' ? 1 : -1,
-          },
-        });
+          };
+        } else {
+          pipeline.push({
+            $sort: {
+              [stage.form.field]: stage.form.order === 'asc' ? 1 : -1,
+            },
+          });
+        }
         break;
       }
       case PipelineStage.GROUP: {


### PR DESCRIPTION
# Description
Pipeline sorting on multiple fields didn't work because of the multiple sort stages added to the pipeline, the sorting was done separately for each field and not considering nested sorting.
Now a unique sort stage is added to the pipeline array, so all the fields with their criteria are considered for the nested sorting.

## Useful links
- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/78304

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Create a chart with an aggregation with multiple sort stages: the final data is sorted by all the selected fields in the selected order, and not only the last sort stage.

## Screenshots
Sorting by number and then by letter (both ascending criteria) (2023-O00000008 is a zero A and 2023-O00000005 is a zero E)

![number + letter](https://github.com/ReliefApplications/ems-backend/assets/28535394/e47ee7db-7d9a-443b-92a4-45b921b802b9)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
