### PR TITLE
AB#78826: Some pages can't open with new gridster changes

### DIFF
--- a/src/schema/types/dashboard.type.ts
+++ b/src/schema/types/dashboard.type.ts
@@ -19,7 +19,16 @@ export const DashboardType = new GraphQLObjectType({
     name: { type: GraphQLString },
     createdAt: { type: GraphQLString },
     modifiedAt: { type: GraphQLString },
-    structure: { type: GraphQLJSON },
+    structure: {
+      type: GraphQLJSON,
+      resolve(parent) {
+        if (Array.isArray(parent.structure)) {
+          return parent.structure;
+        } else {
+          return [];
+        }
+      },
+    },
     buttons: { type: GraphQLJSON },
     permissions: {
       type: AccessType,


### PR DESCRIPTION
# Description

The problem was related to the dashboard entity that was not prepared for the situation where the 'structure' attribute was of a different type of array. With Antoine's help, we solved the problem by treating the situation where the field is different from an array.

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/78826)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] I edited the database so that a specific dashboard had the 'structure' field as {}. After emulating the problem, I changed the entity and the error no longer occurred.

## Screenshots

Dashboard with the 'structure' field set to {} (after changes):
![1](https://github.com/ReliefApplications/ems-backend/assets/55603259/d481ea4b-b416-4071-bff8-6a3e630f4535)

On database:
![2](https://github.com/ReliefApplications/ems-backend/assets/55603259/dab9239f-ba2c-480d-a5e9-74e59d9b5af4)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
