### PR TITLE
Ab#78944 fix ping request and avoid decrypting twice

### DIFF
--- a/src/routes/proxy/index.ts
+++ b/src/routes/proxy/index.ts
@@ -23,12 +23,19 @@ const SETTING_PLACEHOLDER = '●●●●●●●●●●●●●';
  * @param res response
  * @param api api configuration
  * @param path url path
+ * @param ping bool: are we executing a ping request
  * @returns API request
  */
-const proxyAPIRequest = async (req: Request, res: Response, api, path) => {
+const proxyAPIRequest = async (
+  req: Request,
+  res: Response,
+  api: ApiConfiguration,
+  path: string,
+  ping = false
+) => {
   try {
     let client: RedisClientType;
-    if (config.get('redis.url') && req.method === 'get') {
+    if (config.get('redis.url') && req.method === 'get' && !ping) {
       client = createClient({
         url: config.get('redis.url'),
         password: config.get('redis.password'),
@@ -46,7 +53,7 @@ const proxyAPIRequest = async (req: Request, res: Response, api, path) => {
       logger.info(`REDIS: get key : ${url}`);
       res.status(200).send(JSON.parse(cacheData));
     } else {
-      const token = await getToken(api, req.headers.accesstoken);
+      const token = await getToken(api, req.headers.accesstoken, ping);
       await axios({
         url,
         method: req.method,
@@ -116,8 +123,9 @@ router.post('/ping/**', async (req: Request, res: Response) => {
             ).toString(CryptoJS.enc.Utf8)
           )
         : {};
-      const parameters = {
+      const parameters: ApiConfiguration = {
         ...body,
+        authType: api.authType,
         settings: {
           authTargetUrl:
             get(body, 'settings.authTargetUrl', SETTING_PLACEHOLDER) !==
@@ -143,7 +151,7 @@ router.post('/ping/**', async (req: Request, res: Response) => {
       };
 
       req.method = 'GET';
-      await proxyAPIRequest(req, res, parameters, api.pingUrl);
+      await proxyAPIRequest(req, res, parameters, api.pingUrl, true);
     }
   } catch (err) {
     logger.error(err.message, { stack: err.stack });

--- a/src/server/apollo/dataSources.ts
+++ b/src/server/apollo/dataSources.ts
@@ -252,7 +252,7 @@ export class CustomAPI extends RESTDataSource {
             .join(lastUpdate);
           break;
         default:
-          console.error('Unknown variable on refData query', variable);
+          logger.error('Unknown variable on refData query', variable);
       }
     }
     return processedQuery;

--- a/src/utils/proxy/authManagement.ts
+++ b/src/utils/proxy/authManagement.ts
@@ -4,6 +4,7 @@ import * as CryptoJS from 'crypto-js';
 import NodeCache from 'node-cache';
 import config from 'config';
 import axios from 'axios';
+import { logger } from '@services/logger.service';
 
 /**
  * Create a cache instance to store authentication tokens for ApiConfigurations.
@@ -97,12 +98,14 @@ export const getToken = async (
   }
   if (apiConfiguration.authType === authType.userToService) {
     // Retrieve access token from settings, store it and return it
-    const settings: { token: string } = JSON.parse(
-      CryptoJS.AES.decrypt(
-        apiConfiguration.settings,
-        config.get('encryption.key')
-      ).toString(CryptoJS.enc.Utf8)
-    );
+    const settings: { token: string } = ping
+      ? apiConfiguration.settings
+      : JSON.parse(
+          CryptoJS.AES.decrypt(
+            apiConfiguration.settings,
+            config.get('encryption.key')
+          ).toString(CryptoJS.enc.Utf8)
+        );
     cache.set(tokenID, settings.token, 3570);
     return settings.token;
   }
@@ -111,7 +114,7 @@ export const getToken = async (
     return accessToken.toString();
     // Token doesn't need to be cached since the frontend always keeps it up-to-date
   }
-  console.error(`API auth type ${apiConfiguration.authType} is not recognized`);
+  logger.error(`API auth type ${apiConfiguration.authType} is not recognized`);
 };
 
 /**


### PR DESCRIPTION
# Description

- Added a boolean **ping** for the **proxyApiRequest** and **getToken** functions. It avoids caching and decryting settings a second time.
- Changed the authType for the ping request: it was acquired from the body instead of the database, thus _serviceToService_ instead of _service-to-service_, which lead **getToken** to fail.
- Added an error message in the **getToken** function when the authType is not recognized.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/78944/)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Tried ping requests => failed before changes, now work. Ensured ping was set to true when pinging and to false when not pinging.

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
