### PR TITLE
fix/AB#79481_roles_dont_appear_in_users_application

### DIFF
--- a/src/schema/types/user.type.ts
+++ b/src/schema/types/user.type.ts
@@ -50,7 +50,7 @@ export const UserType = new GraphQLObjectType({
         if (parent.roles && typeof parent.roles === 'object') {
           const roles = await Role.find(accessibleBy(ability, 'read').Role)
             .where('_id')
-            .in(parent.roles.map((x) => x._id));
+            .in(parent.roles.map((x) => (x._id ? x._id : x)));
           return roles;
         } else {
           const roles = await Role.find(accessibleBy(ability, 'read').Role)


### PR DESCRIPTION
# Description
In the user type, sometimes the parent.roles items was the role id and not the role object and because of that the list returned was always empty. 

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/79481

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Open the users list inside an application.

## Screenshots
![role](https://github.com/ReliefApplications/ems-backend/assets/28535394/bf8ffca0-fc7a-41bb-b319-18776ec01cb3)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
