### PR TITLE
AB#79869_incorrect_cursor_when_no_sorting

### DIFF
--- a/src/schema/query/apiConfigurations.query.ts
+++ b/src/schema/query/apiConfigurations.query.ts
@@ -53,7 +53,9 @@ export default {
 
       let items: any[] = await ApiConfiguration.find({
         $and: [cursorFilters, ...filters],
-      }).limit(first + 1);
+      })
+        .sort({ _id: 1 })
+        .limit(first + 1);
 
       const hasNextPage = items.length > first;
       if (hasNextPage) {

--- a/src/schema/query/pullJobs.query.ts
+++ b/src/schema/query/pullJobs.query.ts
@@ -50,7 +50,9 @@ export default {
 
       let items: any[] = await PullJob.find({
         $and: [cursorFilters, ...filters],
-      }).limit(first + 1);
+      })
+        .sort({ _id: 1 })
+        .limit(first + 1);
 
       const hasNextPage = items.length > first;
       if (hasNextPage) {


### PR DESCRIPTION
# Description

Having no sorting on cursor queries causes missing data because ids can be unordered (mostly because of time zones). Added a sorting on ids fixes it (api config and pull jobs)

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/79869)
- [Order in mongo ids](https://stackoverflow.com/questions/31057827/is-mongodb-id-objectid-generated-in-an-ascending-order)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Copied one of my records from pull jobs and changed manually its id to a previous one. Data is lacking from paginated tabs. Added a sort on id and all is in order

## Screenshots

Before:
<img width="1175" alt="Screenshot 2023-11-27 at 09 51 06" src="https://github.com/ReliefApplications/ems-backend/assets/59645813/122907d8-0d22-4738-a01e-2315dab45bb3">

After:
<img width="1163" alt="Screenshot 2023-11-27 at 10 09 45" src="https://github.com/ReliefApplications/ems-backend/assets/59645813/ea9995f6-d011-4b74-9741-c73cff0e3e19">


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules