### PR TITLE
Ab#67193 upload record from excel

### DIFF
--- a/src/utils/files/loadRow.ts
+++ b/src/utils/files/loadRow.ts
@@ -1,7 +1,6 @@
 import { isArray, isNil } from 'lodash';
 import set from 'lodash/set';
 import { PositionAttribute } from '@models';
-import { JSONObject } from 'graphql-scalars/typings/mocks';
 
 /**
  * Transforms uploaded row into record data, using fiels definition.

--- a/src/utils/files/loadRow.ts
+++ b/src/utils/files/loadRow.ts
@@ -1,6 +1,7 @@
 import { isArray, isNil } from 'lodash';
 import set from 'lodash/set';
 import { PositionAttribute } from '@models';
+import { JSONObject } from 'graphql-scalars/typings/mocks';
 
 /**
  * Transforms uploaded row into record data, using fiels definition.
@@ -68,6 +69,10 @@ export const loadRow = (
             value,
             category: column.category,
           });
+          break;
+        }
+        case 'geospatial': {
+          data[column.field] = JSON.parse(value);
           break;
         }
         default: {


### PR DESCRIPTION
# Description

Created a geospatial type case for the switch in loadRow. Without it, uploading records with geospatial questions would upload the json object as a string and break some functionalities.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/67193

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Create a form with a geospatial question, set some records manually, download those records.
- Uploading these records to any resource now should work and the label for the geospatial question should now be City, Country or similar instead of a JSON object as a string.

## Screenshots

![image](https://github.com/ReliefApplications/ems-backend/assets/39497117/dfff0a9f-eddc-4a1c-a394-f83de9a43081)
(Before)

![image](https://github.com/ReliefApplications/ems-backend/assets/39497117/764d17d7-3633-4c87-a800-41d58039c8ba)
(After)

# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings