### PR TITLE
refactor: reference data pipeline stage 

### DIFF
--- a/src/models/referenceData.model.ts
+++ b/src/models/referenceData.model.ts
@@ -2,6 +2,7 @@ import { AccessibleRecordModel, accessibleRecordsPlugin } from '@casl/mongoose';
 import mongoose, { Schema, Document } from 'mongoose';
 import { getGraphQLTypeName } from '@utils/validators';
 import { referenceDataType } from '@const/enumTypes';
+import { snakeCase } from 'lodash';
 
 /** Reference data document interface. */
 interface ReferenceDataDocument extends Document {
@@ -92,7 +93,7 @@ schema.statics.getGraphQLTypeName = function (name: string): string {
 };
 
 schema.statics.getGraphQLFieldName = function (name: string): string {
-  return getGraphQLTypeName(name);
+  return snakeCase(name);
 };
 
 // Search for duplicate, using graphQL type name

--- a/src/utils/aggregation/buildReferenceDataAggregation.ts
+++ b/src/utils/aggregation/buildReferenceDataAggregation.ts
@@ -34,7 +34,25 @@ const buildReferenceDataAggregation = async (
     // Log error but continue execution
     logger.error(err.message, { stack: err.stack });
   }
+
+  // We map the items to create objects with the graphQLFieldName as key and the value as value.
+  const mappedItems = items.map((item) => {
+    const newItem = Object.keys(item).reduce((obj, key) => {
+      const currField = referenceData.fields.find((f) => f.name === key);
+      if (currField) {
+        obj[currField.graphQLFieldName ?? key] = item[key];
+      }
+      return obj;
+    }, {});
+
+    return newItem;
+  });
+
   const itemsIds = items.map((item) => item[referenceData.valueField]);
+  const valueFieldGraphqlName = referenceData.fields.find(
+    (f) => f.name === referenceData.valueField
+  )?.graphQLFieldName;
+
   if (MULTISELECT_TYPES.includes(field.type)) {
     return [
       {
@@ -55,14 +73,16 @@ const buildReferenceDataAggregation = async (
           [`data.${field.name}`]: {
             $let: {
               vars: {
-                items,
+                items: mappedItems,
               },
               in: {
                 $filter: {
                   input: '$$items',
                   cond: {
                     $in: [
-                      `$$this.${referenceData.valueField}`,
+                      `$$this.${
+                        valueFieldGraphqlName ?? referenceData.valueField
+                      }`,
                       `$data.${field.name}`,
                     ],
                   },
@@ -80,7 +100,7 @@ const buildReferenceDataAggregation = async (
           [`data.${field.name}`]: {
             $let: {
               vars: {
-                items,
+                items: mappedItems,
                 itemsIds,
               },
               in: {

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -426,7 +426,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
 
       // If we're using skip parameter, include them into the aggregation
       if (skip || skip === 0) {
-        const aggregation = await Record.aggregate([
+        const pipeline = [
           { $match: basicFilters },
           ...(at ? getAtAggregation(new Date(at)) : []),
           ...linkedRecordsAggregation,
@@ -446,7 +446,8 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
               ],
             },
           },
-        ]);
+        ];
+        const aggregation = await Record.aggregate(pipeline);
         items = aggregation[0].items;
         totalCount = aggregation[0]?.totalCount[0]?.count || 0;
       } else {
@@ -458,7 +459,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
               },
             }
           : {};
-        const aggregation = await Record.aggregate([
+        const pipeline = [
           { $match: basicFilters },
           ...linkedRecordsAggregation,
           ...linkedReferenceDataAggregation,
@@ -475,7 +476,8 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
               ],
             },
           },
-        ]);
+        ];
+        const aggregation = await Record.aggregate(pipeline);
         items = aggregation[0].items;
         totalCount = aggregation[0]?.totalCount[0]?.count || 0;
       }


### PR DESCRIPTION
# Description

So a very annoying problem with the reference data is the name/graphqlfieldname situation. All the queries and filters are built using the graphqlfieldname, because the query builder in the front uses the schema to derive the fields from, but the data itself uses the name.

A few months ago, [this PR](https://github.com/ReliefApplications/ems-backend/pull/650/files) kinda addressed the problem, but only solved the issues on the aggregations and didn't really fix the problem, just worked around it in a weird way. 

I reverted those changes and instead changed the refData pipeline stage to map the items to new objects using the graphqlfieldname as keys

In addition, I also changed the function we use to calculate the graphqlfieldname to be snakeCase, which is the same we use for the resource field names, to keep the pattern

## Useful links

- Please insert link to ticket
- Please insert link to front-end branch if any
- Please insert any useful link ( documentation you used for example )

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

* Created a resource with tagbox with choices from refData, added a grid and an aggregation
* Filter and sort by values from the refData on the grid (not working before)

## Screenshots

![Peek 2023-12-08 00-12](https://github.com/ReliefApplications/ems-backend/assets/102038450/fcef0f63-2d7e-4eb9-8f3f-e0ff2452c263)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
