### PR TITLE
AB#80839_fix_reference_data_export

### DIFF
--- a/src/utils/files/getColumnsFromMeta.ts
+++ b/src/utils/files/getColumnsFromMeta.ts
@@ -15,10 +15,11 @@ export const getColumnsFromMeta = (
   for (const key in meta) {
     const field = meta[key];
     if (field && field.name && typeof field.name === 'string') {
+      const name = field.graphQLFieldName ?? field.name; //takes into account reference data
       // Classic field
       columns.push({
-        name: prefix ? `${prefix}.${field.name}` : field.name,
-        field: prefix ? `${prefix}.${field.name}` : field.name,
+        name: prefix ? `${prefix}.${name}` : name,
+        field: prefix ? `${prefix}.${name}` : name,
         type: field.type,
         meta: {
           field,


### PR DESCRIPTION
# Description

Change the way we get the name from the columns: if there is a graphQLfieldName (should be only for reference data), we get it instead of the regular name: this way we correctly get reference data columns

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/80839/)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Create a form with some reference data. Upon exporting, everything should go well and you should have the reference data columns.

## Screenshots

# Checklist:

( * == Mandatory ) 

- [ ] * I have set myself as assignee of the pull request
- [ ] * My code follows the style guidelines of this project
- [ ] * Linting does not generate new warnings
- [ ] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [ ] * I have commented my code, particularly in hard-to-understand areas
- [ ] * I have put JSDoc comment in all required places
- [ ] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
