### PR TITLE
fix/AB#81524_aggregation_on_refData_not_working

### DIFF
--- a/src/schema/query/referenceDataAggregation.query.ts
+++ b/src/schema/query/referenceDataAggregation.query.ts
@@ -113,7 +113,12 @@ const procOperator = (data: any, operator) => {
  * @param referenceDataFields referenceData fields
  * @returns filtered data
  */
-const procPipelineStep = (pipelineStep, data, sourceFields, referenceDataFields) => {
+const procPipelineStep = (
+  pipelineStep,
+  data,
+  sourceFields,
+  referenceDataFields
+) => {
   switch (pipelineStep.type) {
     case 'group':
       const operators = pipelineStep.form?.addFields?.map(
@@ -251,7 +256,12 @@ export default {
           }
 
           aggregation.pipeline.forEach((step: any) => {
-            items = procPipelineStep(step, items, aggregation.sourceFields, referenceData.fields);
+            items = procPipelineStep(
+              step,
+              items,
+              aggregation.sourceFields,
+              referenceData.fields
+            );
           });
           if (args.mapping) {
             return items.map((item) => {

--- a/src/schema/query/referenceDataAggregation.query.ts
+++ b/src/schema/query/referenceDataAggregation.query.ts
@@ -110,16 +110,27 @@ const procOperator = (data: any, operator) => {
  * @param pipelineStep step of the pipeline to build a result from
  * @param data the reference data
  * @param sourceFields fields we want to get in our final data
+ * @param referenceDataFields referenceData fields
  * @returns filtered data
  */
-const procPipelineStep = (pipelineStep, data, sourceFields) => {
+const procPipelineStep = (pipelineStep, data, sourceFields, referenceDataFields) => {
   switch (pipelineStep.type) {
     case 'group':
       const operators = pipelineStep.form?.addFields?.map(
         (operator) => operator.expression
       );
+      const mappedData = data.map((item) => {
+        const newItem = Object.keys(item).reduce((obj, key) => {
+          const currField = referenceDataFields.find((f) => f.name === key);
+          if (currField) {
+            obj[currField.graphQLFieldName ?? key] = item[key];
+          }
+          return obj;
+        }, {});
+        return newItem;
+      });
       const keysToGroupBy = pipelineStep.form.groupBy.map((key) => key.field);
-      data = groupBy(data, (dataKey) =>
+      data = groupBy(mappedData, (dataKey) =>
         keysToGroupBy.map((key) => dataKey[key])
       );
       for (const key in data) {
@@ -240,7 +251,7 @@ export default {
           }
 
           aggregation.pipeline.forEach((step: any) => {
-            items = procPipelineStep(step, items, aggregation.sourceFields);
+            items = procPipelineStep(step, items, aggregation.sourceFields, referenceData.fields);
           });
           if (args.mapping) {
             return items.map((item) => {


### PR DESCRIPTION
# Description

Fixed: Aggregation on ref data not working if using a field where the name is not the same than the graphql name.

## Useful links

[ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/81524)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested creating a chart with reference data and trying to group by some field name.

## Screenshots

![Peek 12-12-2023 14-48](https://github.com/ReliefApplications/ems-backend/assets/56398308/338ba40b-342d-4fe5-91dc-03157f500dee)


# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules