### PR TITLE
fix: aggregation on null question using choices from refData

### DIFF
--- a/src/utils/aggregation/buildReferenceDataAggregation.ts
+++ b/src/utils/aggregation/buildReferenceDataAggregation.ts
@@ -100,7 +100,10 @@ const buildReferenceDataAggregation = async (
           [`data.${field.name}`]: {
             $let: {
               vars: {
-                items: mappedItems,
+                // We concat null at the end because if there is no value for a particular record
+                // indexOfArray would return -1 and if we pass a negative index (-n for example) to $arrayElemAt
+                // it would return the nth element starting from the last element of the array
+                items: mappedItems.concat(null),
                 itemsIds,
               },
               in: {


### PR DESCRIPTION
# Description

Fixes an issue when aggregating data that has a question with choices from refData. If there was no value for a specific record, the last item of the refData options would be used by default

## Useful links

- Please insert link to ticket: No ticket


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By creating a form with a dropdown with choices coming from refData, adding a record without selecting values for it and creating an aggregation that uses that field

## Screenshots
In the following example, 35 records had null for the question that had choices coming form reference data, I'm simply grouping the records by that question 

Before fix:
![image](https://github.com/ReliefApplications/ems-backend/assets/102038450/77473bf2-a6f7-46f0-8fea-e72346db799a)


After fix: 
![image](https://github.com/ReliefApplications/ems-backend/assets/102038450/ecd1f3cf-96e8-458f-83a0-ca145e1aa606)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
