### PR TITLE
fix/AB#82914-duplication-of-app-sometimes-fail 

### DIFF
--- a/src/schema/mutation/duplicateApplication.mutation.ts
+++ b/src/schema/mutation/duplicateApplication.mutation.ts
@@ -216,9 +216,11 @@ export default {
                 }
 
                 // Add the new permissions to the field
-                field.permissions[permType].push(...newPermissions);
-                added = true;
-                resource.markModified('fields');
+                if (field.permissions[permType]) {
+                  field.permissions[permType].push(...newPermissions);
+                  added = true;
+                  resource.markModified('fields');
+                }
               });
             });
             if (added) {


### PR DESCRIPTION
# Description
I couldn't reproduce the error either on 2.x.x or beta branch using my local backend and my own mongo DB data (trying to duplicate applications with distribution lists, templates, custom notifications, styles, etc).

But when using the shared backend or the [oort-dev env](https://oort-dev.oortcloud.tech/admin/applications/), the error occurred for all the applications i tried, even the ones without distribution lists / templates, so it doesn't seem to be the problem. 

Testing using the oortdev DB locally, I was able to find the error: when a field didn't had a permission (for example, had the 'canSee' permission but not the 'canUpdate' permission) the mutation was trying to add a permission that didn't exist for the duplicated application

## Useful links
- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82914

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Try to duplicate applications (with or without a bunch of pages or distribution lists, templates, custom notifications, styles, etc)

## Screenshots
[duplicate.webm](https://github.com/ReliefApplications/ems-backend/assets/28535394/3331b14e-a6b1-44d9-83c9-eca5fb4a430b)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
