### PR TITLE
fix/AB#82958-after-duplicating-application-page-refresh-necessary

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -107,7 +107,13 @@ class SafeServer {
         const updatedDocFields = Object.keys(
           data.updateDescription.updatedFields
         );
+        // Permissions update on the fields should not be considered as a change of the schema
+        const updatePermissions = Object.hasOwn(
+          data.updateDescription.updatedFields,
+          'permissions'
+        );
         if (
+          !updatePermissions &&
           updatedDocFields.some(
             (f) =>
               fieldsThatRequireSchemaUpdate.includes(f) &&
@@ -246,16 +252,14 @@ class SafeServer {
 
   /** Re-launches the server with updated schema */
   private async update(): Promise<void> {
-    setTimeout(async () => {
-      const schema = await buildSchema();
-      this.httpServer.removeListener('request', this.app);
-      this.httpServer.close();
-      logger.info('🛑 Stopping server');
-      this.apolloServer.stop().then(() => {
-        logger.info('🔁 Reloading server');
-        this.start(schema);
-      });
-    }, 5000);
+    const schema = await buildSchema();
+    this.httpServer.removeListener('request', this.app);
+    this.httpServer.close();
+    logger.info('🛑 Stopping server');
+    this.apolloServer.stop().then(() => {
+      logger.info('🔁 Reloading server');
+      this.start(schema);
+    });
   }
 }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -186,14 +186,16 @@ class SafeServer {
 
   /** Re-launches the server with updated schema */
   private async update(): Promise<void> {
-    const schema = await buildSchema();
-    this.httpServer.removeListener('request', this.app);
-    this.httpServer.close();
-    logger.info('🛑 Stopping server');
-    this.apolloServer.stop().then(() => {
-      logger.info('🔁 Reloading server');
-      this.start(schema);
-    });
+    setTimeout(async () => {
+      const schema = await buildSchema();
+      this.httpServer.removeListener('request', this.app);
+      this.httpServer.close();
+      logger.info('🛑 Stopping server');
+      this.apolloServer.stop().then(() => {
+        logger.info('🔁 Reloading server');
+        this.start(schema);
+      });
+    }, 5000);
   }
 }
 


### PR DESCRIPTION
# Description

The problem was after duplicating applications with content, the backend would re-launches the server with updated schema because the resource changes require schema update, so the redirection to the new duplicated application didn't happen with the server down. So if you duplicate an empty application, for example, it will open the new application as it should without problems since the backend doesn't reload the server in this case.

Added a new check in the resource calculated fields updates watch that triggered this schema refresh, so when the calculated fields are updated the server will reload as wanted, but not on the calculated fields permissions updates.

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82958

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
Duplicating applications

## Screenshots
[dup.webm](https://github.com/ReliefApplications/ems-backend/assets/28535394/0d874d78-10da-4621-8310-8112dcb13d68)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
