### PR TITLE
feat/AB#83059-remove-useless-graphql-fields-in-widget-queries

### DIFF
--- a/src/schema/types/resource.type.ts
+++ b/src/schema/types/resource.type.ts
@@ -138,6 +138,22 @@ export const ResourceType = new GraphQLObjectType({
         return forms;
       },
     },
+    form: {
+      type: FormType,
+      args: {
+        id: { type: GraphQLID },
+      },
+      async resolve(parent, args, context) {
+        if (args.id) {
+          const ability: AppAbility = context.user.ability;
+          const form = await Form.findById({
+            _id: args.id,
+            ...accessibleBy(ability, 'read').Form,
+          });
+          return form;
+        }
+      },
+    },
     relatedForms: {
       type: new GraphQLList(FormType),
       async resolve(parent, args, context) {

--- a/src/schema/types/resource.type.ts
+++ b/src/schema/types/resource.type.ts
@@ -377,8 +377,15 @@ export const ResourceType = new GraphQLObjectType({
     },
     metadata: {
       type: new GraphQLList(FieldMetaDataType),
-      resolve(parent, _, context) {
-        return getMetaData(parent, context);
+      args: {
+        // To ignore all the metadata data (to cases when the summary card widget don't use a layout so don't need
+        // metadata info to build fields and send this data is useless)
+        ignore: { type: GraphQLBoolean },
+      },
+      resolve(parent, args, context) {
+        if (!args.ignore) {
+          return getMetaData(parent, context);
+        }
       },
     },
   }),


### PR DESCRIPTION
# Description
Updated resource type: the field "forms now have the optional args "id" and "ignore": getting a form id returns a single form (resource template) instead of all of the data, and getting the boolean "ignore" all the data will be ignore and not fetched, this, because the grid don't have a template and send this data to the front-end, is useless.

Updated the fields "layouts" and "aggregations" with the same args "ignore" so we don't fetch useless data if the widget doesn't use layouts or aggregations.

Also updated the field "metadata" with the args "ignore" to ignore all the metadata data (in cases when the summary card widget doesn't use a layout so don't need metadata info to build fields and send this data is useless).

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83059
- Please insert link to front-end branch if any: https://github.com/ReliefApplications/ems-frontend/pull/2267

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
Testing the resource query with a ignore args and a form id args for all the cases for grid and summary card widgets

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
