### PR TITLE
feat: add pagination info to reference data

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -218,7 +218,7 @@
 			"edit": {
 				"errors": {
 					"formResDuplicated": "A form or a resource with that name already exists.",
-					"invalidArguments": "Either name, type, apiConfiguration, query, fields, valueField, path, data or permissions must be provided."
+					"invalidArguments": "Either name, type, pageInfo, apiConfiguration, query, fields, valueField, path, data or permissions must be provided."
 				}
 			}
 		},

--- a/src/models/referenceData.model.ts
+++ b/src/models/referenceData.model.ts
@@ -69,6 +69,35 @@ interface ReferenceDataDocument extends Document {
     canDelete?: any[];
   };
   aggregations: any;
+
+  // Pagination strategies
+  //  offset: The client will send the offset (how many items to skip)
+  //  cursor: The client will send the cursor of the last item
+  //  page: The client will send the page number
+  pageInfo?: {
+    // JSON path that when queried to the API response will return the total number of items
+    totalCountField: string;
+    // Name of the query variable that corresponds to the page size
+    pageSizeVar?: string;
+  } & (
+    | {
+        strategy: 'offset';
+        // Name of the query variable to be used for determining the offset
+        offsetVar: string;
+      }
+    | {
+        strategy: 'cursor';
+        // JSON path that when queried to the API response will return the cursor
+        cursorField: string;
+        // Name of the query variable to be used for determining the cursor
+        cursorVar: string;
+      }
+    | {
+        strategy: 'page';
+        // Name of the query variable that corresponds to the page number
+        pageVar: string;
+      }
+  );
 }
 
 /** Interface of Reference Data */
@@ -128,6 +157,18 @@ const schema = new Schema<ReferenceData>(
       ],
     },
     aggregations: [aggregationSchema],
+    pageInfo: {
+      strategy: {
+        type: String,
+        enum: ['offset', 'cursor', 'page'],
+      },
+      cursorField: String,
+      cursorVar: String,
+      offsetVar: String,
+      pageVar: String,
+      pageSizeVar: String,
+      totalCountField: String,
+    },
   },
   {
     timestamps: { createdAt: 'createdAt', updatedAt: 'modifiedAt' },

--- a/src/routes/gis/index.ts
+++ b/src/routes/gis/index.ts
@@ -316,7 +316,7 @@ router.get('/feature', async (req, res) => {
     adminField,
   };
   try {
-    // todo(gis): also implement reference data
+    // Fetch resource to populate layer
     if (get(req, 'query.resource')) {
       let id: string;
       if (get(req, 'query.aggregation')) {
@@ -393,6 +393,7 @@ router.get('/feature', async (req, res) => {
         throw new Error(err);
       });
     } else if (get(req, 'query.refData')) {
+      // Else, fetch reference data to populate layer
       const referenceData = await ReferenceData.findById(
         new mongoose.Types.ObjectId(get(req, 'query.refData') as string)
       );
@@ -433,7 +434,6 @@ router.get('/feature', async (req, res) => {
             mapping
           );
         } else {
-          // todo: populate
           const apiConfiguration = await ApiConfiguration.findById(
             referenceData.apiConfiguration,
             'name endpoint graphQLEndpoint'

--- a/src/schema/mutation/editReferenceData.mutation.ts
+++ b/src/schema/mutation/editReferenceData.mutation.ts
@@ -3,6 +3,7 @@ import {
   GraphQLID,
   GraphQLError,
   GraphQLString,
+  GraphQLInputObjectType,
 } from 'graphql';
 import { Form, ReferenceData } from '@models';
 import { ReferenceDataType } from '../types';
@@ -56,6 +57,20 @@ export default {
     data: { type: GraphQLJSON },
     graphQLFilter: { type: GraphQLString },
     permissions: { type: GraphQLJSON },
+    pageInfo: {
+      type: new GraphQLInputObjectType({
+        name: 'PageInfoInput',
+        fields: {
+          totalCountField: { type: new GraphQLNonNull(GraphQLString) },
+          strategy: { type: new GraphQLNonNull(GraphQLString) },
+          pageSizeVar: { type: GraphQLString },
+          cursorVar: { type: GraphQLString },
+          cursorField: { type: GraphQLString },
+          pageVar: { type: GraphQLString },
+          offsetVar: { type: GraphQLString },
+        },
+      }),
+    },
   },
   async resolve(parent, args: EditReferenceDataArgs, context: Context) {
     graphQLAuthCheck(context);

--- a/src/schema/mutation/editReferenceData.mutation.ts
+++ b/src/schema/mutation/editReferenceData.mutation.ts
@@ -61,7 +61,7 @@ export default {
       type: new GraphQLInputObjectType({
         name: 'PageInfoInput',
         fields: {
-          totalCountField: { type: new GraphQLNonNull(GraphQLString) },
+          totalCountField: { type: GraphQLString },
           strategy: { type: new GraphQLNonNull(GraphQLString) },
           pageSizeVar: { type: GraphQLString },
           cursorVar: { type: GraphQLString },

--- a/src/schema/types/referenceData.type.ts
+++ b/src/schema/types/referenceData.type.ts
@@ -112,6 +112,20 @@ export const ReferenceDataType = new GraphQLObjectType({
         };
       },
     },
+    pageInfo: {
+      type: new GraphQLObjectType({
+        name: 'ReferenceDataPaginationDefinition',
+        fields: () => ({
+          strategy: { type: GraphQLString },
+          cursorField: { type: GraphQLString },
+          cursorVar: { type: GraphQLString },
+          offsetVar: { type: GraphQLString },
+          pageVar: { type: GraphQLString },
+          pageSizeVar: { type: GraphQLString },
+          totalCountField: { type: GraphQLString },
+        }),
+      }),
+    },
   }),
 });
 

--- a/src/server/pullJobScheduler.ts
+++ b/src/server/pullJobScheduler.ts
@@ -297,8 +297,8 @@ const getUserRoleFiltersFromApp = (appName: string): any => {
  *
  * @param data array of data fetched from API
  * @param pullJob pull job configuration
- * @param fromRoute tells if the insertion is done from pull-job or route
  * @param isEIOS is EIOS pulljob or not
+ * @param fromRoute tells if the insertion is done from pull-job or route
  */
 export const insertRecords = async (
   data: any[],


### PR DESCRIPTION
# Description

This PR adds support to pagination on summary cards with reference data datasource.

On the reference data definition, a few options about pagination were added:
* usePagination: if the refData in question uses pagination
* strategy: 'offset', 'cursor' or 'page'
* other options based on the strategy (those and the strategy itself can be auto-filled based on the query variable names)
On the summary cards:
* selecting reference data as datasource allows the user to map values to the available query variables using the dashboard filters templates
* moving between pages will properly fetch data using our proxy and handles pagination for each strategy


## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83067
- Please insert link to front-end branch if any: https://github.com/ReliefApplications/ems-frontend/pull/2275

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Reference datas (and api configurations) tested: 

```json
[
  {
    "name": "r&m_episodes",
    "apiConfiguration": {
      "name": "rick_and_morty",
      "status": "active",
      "authType": "public",
      "endpoint": "https://rickandmortyapi.graphcdn.app/",
      "graphQLEndpoint": "/",
      "pingUrl": ""
    },
    "type": "graphql",
    "query": "# You can use {{lastUpdate}} to dynamically get the last fetch date in SQL format.\n\nquery Episodes($page: Int, $episodeName: String) {\n  episodes(page: $page, filter: {name: $episodeName}) {\n    results {\n      id\n      name\n    }\n    info {\n      pages\n      count\n      next\n      prev\n    }\n  }\n}\n",
    "valueField": "id",
    "path": "$.data.episodes.results.*",
    "pageInfo": {
      "strategy": "page",
      "pageVar": "page",
      "totalCountField": "$.data.episodes.info.count"
    }
  },
  {
    "name": "sw_planets",
    "apiConfiguration": {
      "name": "star_wars",
      "status": "active",
      "authType": "public",
      "endpoint": "https://swapi-graphql.netlify.app/.netlify/functions/index/",
      "pingUrl": "/",
      "graphQLEndpoint": "/"
    },
    "type": "graphql",
    "query": "query Planets($cursor: String, $pageSize: Int) {\n  allPlanets(after: $cursor, first: $pageSize) {\n    edges {\n      node {\n        id\n        name\n        diameter\n        gravity\n      }\n      cursor\n    }\n    totalCount\n  }\n}",
    "valueField": "id",
    "path": "$.data.allPlanets.edges.*.node",
    "pageInfo": {
      "strategy": "cursor",
      "cursorField": "$.data.allPlanets.edges.*.cursor",
      "cursorVar": "cursor",
      "pageSizeVar": "pageSize",
      "totalCountField": "$.data.allPlanets.totalCount"
    }
  },
  {
    "name": "pokemon_list",
    "apiConfiguration": {
      "name": "pokemon",
      "status": "active",
      "authType": "public",
      "endpoint": "https://beta.pokeapi.co/graphql/v1beta/",
      "pingUrl": null,
      "graphQLEndpoint": "/"
    },
    "type": "graphql",
    "query": "query Pokemon($pageSize: Int, $offset: Int) {\n  pokemon_v2_pokemonform(limit: $pageSize, offset: $offset) {\n    id\n    name\n  }\n}\n",
    "valueField": "id",
    "path": "$.data.pokemon_v2_pokemonform.*",
    "pageInfo": {
      "strategy": "offset",
      "offsetVar": "offset",
      "pageSizeVar": "pageSize",
      "totalCountField": null
    }
  }
]

```

## Screenshots

![Peek 2023-12-08 00-12](https://github.com/ReliefApplications/ems-frontend/assets/102038450/747ed7db-5dab-4eaa-8833-1a0cdd99a773)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
