### PR TITLE
fix/AB#83339-'or'-logic-with-no-filter-value-prevents-data-loading

### DIFF
--- a/src/schema/query/referenceDataAggregation.query.ts
+++ b/src/schema/query/referenceDataAggregation.query.ts
@@ -47,7 +47,9 @@ const applyFilters = (data: any, filter: any): boolean => {
   if (filter.logic) {
     switch (filter.logic) {
       case 'or':
-        return filter.filters.some((f: any) => applyFilters(data, f));
+        return filter.filters.length
+          ? filter.filters.some((f: any) => applyFilters(data, f))
+          : true;
       case 'and':
         return filter.filters.every((f: any) => applyFilters(data, f));
       default:

--- a/src/utils/referenceData/referenceDataFilter.util.ts
+++ b/src/utils/referenceData/referenceDataFilter.util.ts
@@ -14,7 +14,9 @@ export const filterReferenceData = (item: any, filter: any) => {
     );
     return filter.logic === 'and'
       ? results.every(Boolean)
-      : results.some(Boolean);
+      : results.length
+      ? results.some(Boolean)
+      : true;
   } else {
     const value = get(item, filter.field);
     let intValue: number | null;


### PR DESCRIPTION
# Description
Reference data filtering is done manually on front and back-end (without pipelines). And when the filters array was empty, the Array.some() method returns always false on an empty array because it returns false until it finds one where callbackFn returns true. That's why with the 'and' operator it works: since Array.every() used for 'and' filtering finds no elements for which the callback returns false (because the callback never even runs, because there are no elements), it returns true.

Added check to firsts check if the array is empty when filtering with 'or' operators

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83339
- Please insert link to front-end branch if any: https://github.com/ReliefApplications/ems-frontend/pull/2285

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Set a summary card with reference data as data source and context filter for the widget (see ticket for filter example). When changing the dashboard filter or leaving it empty, the data is always correctly filtered/displayed.
# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
