### PR TITLE
feat/AB#83878-improve-layers-performance"

### DIFF
--- a/src/routes/gis/index.ts
+++ b/src/routes/gis/index.ts
@@ -456,13 +456,16 @@ router.get('/feature', async (req, res) => {
             referenceData.apiConfiguration,
             'name endpoint graphQLEndpoint'
           );
-          const contextDataSources = (
-            await dataSources({
-              // Passing upstream request so accesstoken can be used for authentication
-              req: req,
-            } as any)
+          const contextDataSource = (
+            await dataSources(
+              {
+                // Passing upstream request so accesstoken can be used for authentication
+                req: req,
+              } as any,
+              apiConfiguration.name
+            )
           )();
-          const dataSource = contextDataSources[
+          const dataSource = contextDataSource[
             apiConfiguration.name
           ] as CustomAPI;
           let data: any =

--- a/src/schema/types/layer.type.ts
+++ b/src/schema/types/layer.type.ts
@@ -183,7 +183,18 @@ export const LayerType = new GraphQLObjectType({
           title: { type: GraphQLString },
           description: { type: GraphQLString },
           popupElements: { type: new GraphQLList(LayerPopupElement) },
-          fieldsInfo: { type: new GraphQLList(LayerFieldElement) },
+          fieldsInfo: {
+            type: new GraphQLList(LayerFieldElement),
+            resolve(parent) {
+              // Only return fields used on popupElements
+              const fieldsInfo = parent.fieldsInfo.filter((filter) =>
+                parent.popupElements.some((popupElement) =>
+                  popupElement.fields.includes(filter.name)
+                )
+              );
+              return fieldsInfo ?? [];
+            },
+          },
         }),
       }),
     },


### PR DESCRIPTION
# Description
Updated LayerType: fieldsInfo of popupInfo propriety only returns fields used for popup elements.

Updated dataSources(): added apiConfigName parameter, when used it filters the ApiConfiguration objects for only one apiConfig and creates a data source only for this apiConfig

## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/83878

## Type of change
- [X] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?
To test the getLayerById before and after filtering the fieldsInfo update, create a map widget with a layer with popups that use fields.

To test the await dataSources times before and after the filter to search and create data source for only one API configuration you can create a map widget with a layer using a reference data of type rest  as datasource and without aggregations, for example

And put `console.time('operation name')` and `console.timeEnd('operation name')` as used in the screenshots below to get the times.

## Screenshots
getLayerById query before and after fieldsInfo propriety update:
![getLayerById-before](https://github.com/ReliefApplications/ems-backend/assets/28535394/e0ff419b-d9ac-4970-9678-dce58c558aee)
![getLayerById-after](https://github.com/ReliefApplications/ems-backend/assets/28535394/367221c4-8fe5-435e-bb3e-cc2a6b61cafd)

Times before and after update for await dataSources(), ApiConfiguration.find() and ApiConfiguration.findOne() operations:
![find](https://github.com/ReliefApplications/ems-backend/assets/28535394/edb1e137-e68a-4de9-96ab-7fa9cebbf2a4)
![findOne](https://github.com/ReliefApplications/ems-backend/assets/28535394/da578290-8b9a-4060-a0a3-31e9a0471a23)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
