### PR TITLE
Fix/ab#88348 grid does not support is primitive value unchecked

### DIFF
--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -705,15 +705,22 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
           styleRules.push({ items: itemsToStyle, style: style });
         }
       }
-
       // === CONSTRUCT OUTPUT + RETURN ===
+      const referenceDataFields = fields.filter((field) => field.referenceData);
       const edges = items.map((r) => {
         const record = getAccessibleFields(r, ability);
         Object.assign(record, { id: record._id });
+        const node = display ? { ...record, display, fields } : record;
+        referenceDataFields.forEach((field) => {
+          const { value } = node.data[field.name] || {};
+          if (value?.id) {
+            node.data[field.name] = value.id;
+          }
+        });
 
         return {
           cursor: encodeCursor(record.id.toString()),
-          node: display ? Object.assign(record, { display, fields }) : record,
+          node: node,
           meta: {
             style: getStyle(r, styleRules),
             raw: record.data,


### PR DESCRIPTION
# Description

When a question is linked to a reference data, the values saved with the form take different formats depending on whether they are primitive or non-primitive values. As a result, non-primitive value returned an object instead of an id, and the data weren't correctly loaded. It affected all type of widgets (grid, summary cards, and so on). 

To fix it, I manually changed the format from the backend. I'm not sure if it's the best solution and if it might break other functionalities, but according to my tests, it seems to work fine.

## Useful links

- [Please insert link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/88348/)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I created a form with a question linked to a reference data and configured it as non-primitive value. I saved records using it, displayed them in a grid and checked if they were displayed correctly.

## Screenshots

![peek](https://github.com/ReliefApplications/ems-backend/assets/65243509/e1db22a3-8176-42c5-961a-46a5432a21d5)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
