### PR TITLE
AB Email Notification - Permissions

### DIFF
--- a/src/schema/mutation/addEmailNotification.mutation.ts
+++ b/src/schema/mutation/addEmailNotification.mutation.ts
@@ -8,6 +8,7 @@ import {
   EmailNotificationArgs,
   EmailNotificationInputType,
 } from '@schema/inputs/emailNotification.input';
+import extendAbilityForApplications from '@security/extendAbilityForApplication';
 
 /** Arguments for the addCustomNotification mutation */
 type AddCustomNotificationArgs = {
@@ -51,6 +52,19 @@ export default {
         lastExecution: args.notification.lastExecution,
         lastExecutionStatus: args.notification.lastExecutionStatus,
       };
+
+      // Check permission to edit an email notification
+      const user = context.user;
+      const ability = extendAbilityForApplications(
+        user,
+        args.notification.applicationId.toString()
+      );
+      if (ability.cannot('create', 'EmailNotification')) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+
       update.dataSets = update.dataSets.filter(
         (block) => block.resource !== null
       );

--- a/src/security/defineUserAbility.ts
+++ b/src/security/defineUserAbility.ts
@@ -34,6 +34,7 @@ import {
   DistributionList,
   CustomNotification,
   Layer,
+  EmailNotification,
 } from '@models';
 
 /** Define available permissions on objects */
@@ -71,7 +72,8 @@ type Models =
   | Version
   | Workflow
   | CustomNotification
-  | Layer;
+  | Layer
+  | EmailNotification;
 export type Subjects = InferSubjects<Models>;
 
 // eslint-disable-next-line deprecation/deprecation

--- a/src/security/defineUserAbility.ts
+++ b/src/security/defineUserAbility.ts
@@ -179,6 +179,7 @@ export default function defineUserAbility(user: User | Client): AppAbility {
         'Template',
         'DistributionList',
         'CustomNotification',
+        'EmailNotification',
       ]
     );
   } else {

--- a/src/security/extendAbilityForApplication.ts
+++ b/src/security/extendAbilityForApplication.ts
@@ -54,5 +54,30 @@ export default function extendAbilityForApplications(
   if (canManageCustomNotification)
     can(['create', 'delete', 'manage', 'read', 'update'], 'CustomNotification');
 
+  const canSeeEmailNotifications = user.roles?.some(
+    (r) =>
+      r.application?.equals(application) &&
+      r.permissions?.some((p) => p.type === 'can_see_email_notifications')
+  );
+
+  if (canSeeEmailNotifications) can('read', 'EmailNotification');
+
+  const canManageEmailNotifications = user.roles?.some(
+    (r) =>
+      r.application?.equals(application) &&
+      r.permissions?.some((p) => p.type === 'can_manage_email_notifications')
+  );
+
+  if (canManageEmailNotifications)
+    can(['delete', 'update'], 'EmailNotification');
+
+  const canCreateEmailNotifications = user.roles?.some(
+    (r) =>
+      r.application?.equals(application) &&
+      r.permissions?.some((p) => p.type === 'can_create_email_notifications')
+  );
+
+  if (canCreateEmailNotifications) can('create', 'EmailNotification');
+
   return abilityBuilder.build();
 }

--- a/src/server/database.ts
+++ b/src/server/database.ts
@@ -117,6 +117,9 @@ export const initDatabase = async () => {
       'can_manage_templates',
       'can_manage_distribution_lists',
       'can_manage_custom_notifications',
+      'can_see_email_notifications',
+      'can_create_email_notifications',
+      'can_manage_email_notifications',
     ];
     for (const type of appPermissions.filter(
       (perm) => !currPermissions.find((p) => p.type === perm && !p.global)


### PR DESCRIPTION
# Links
[Base PR](https://github.com/ReliefApplications/ems-backend/pull/1005)

[Frontend PR](https://github.com/ReliefApplications/ems-frontend/pull/2491)

# Description

Added permissions checks to resolvers of the editAndGet and add Email Notifications mutations. Manage, read and create permissions are applied to application roles which are then applied to users. These permissions allow the user to perform different actions on email notifications (such as see, manage, create [Read, edit, delete, create]). Front end changes change the visibility of these actions, and throw errors if these actions are accessed by a user with the incorrect permissions.