### PR TITLE
feat/AB#93130_Allow-query-params-to-be-used-for-REST-widgets-using-reference-data-reusable to multiple ref data types

### DIFF
--- a/src/routes/gis/index.ts
+++ b/src/routes/gis/index.ts
@@ -246,8 +246,8 @@ router.post('/feature', async (req, res) => {
     const layerType = (get(req, 'body.type') ||
       GeometryType.POINT) as GeometryType;
     const contextFilters = JSON.parse(get(req, 'body.contextFilters', null));
-    const graphQLVariables = JSON.parse(
-      get(req, 'body.graphQLVariables', null)
+    const referenceDataVariables = JSON.parse(
+      get(req, 'body.referenceDataVariables', null)
     );
     const at = get(req, 'body.at') as string | undefined;
     if (!geoField && !(latitudeField && longitudeField)) {
@@ -358,7 +358,7 @@ router.post('/feature', async (req, res) => {
             $referenceData: ID!
             $aggregation: ID!
             $contextFilters: JSON
-            $graphQLVariables: JSON
+            $referenceDataVariables: JSON
             $first: Int
             $at: Date
           ) {
@@ -366,7 +366,7 @@ router.post('/feature', async (req, res) => {
                 referenceData: $referenceData
                 aggregation: $aggregation
                 contextFilters: $contextFilters
-                graphQLVariables: $graphQLVariables
+                referenceDataVariables: $referenceDataVariables
                 first: $first
                 at: $at
               )
@@ -375,7 +375,7 @@ router.post('/feature', async (req, res) => {
             referenceData: referenceData._id,
             aggregation: aggregation,
             contextFilters,
-            graphQLVariables,
+            referenceDataVariables,
             first: 1000,
             at: at ? new Date(at) : undefined,
           };
@@ -420,7 +420,7 @@ router.post('/feature', async (req, res) => {
             (await dataSource.getReferenceDataItems(
               referenceData,
               apiConfiguration,
-              graphQLVariables
+              referenceDataVariables
             )) || [];
           if (contextFilters && !isEmpty(contextFilters)) {
             data = data.filter((x) => filterReferenceData(x, contextFilters));

--- a/src/routes/gis/index.ts
+++ b/src/routes/gis/index.ts
@@ -246,9 +246,7 @@ router.post('/feature', async (req, res) => {
     const layerType = (get(req, 'body.type') ||
       GeometryType.POINT) as GeometryType;
     const contextFilters = JSON.parse(get(req, 'body.contextFilters', null));
-    const referenceDataVariables = JSON.parse(
-      get(req, 'body.referenceDataVariables', null)
-    );
+    const queryParams = JSON.parse(get(req, 'body.queryParams', null));
     const at = get(req, 'body.at') as string | undefined;
     if (!geoField && !(latitudeField && longitudeField)) {
       return res
@@ -358,7 +356,7 @@ router.post('/feature', async (req, res) => {
             $referenceData: ID!
             $aggregation: ID!
             $contextFilters: JSON
-            $referenceDataVariables: JSON
+            $queryParams: JSON
             $first: Int
             $at: Date
           ) {
@@ -366,7 +364,7 @@ router.post('/feature', async (req, res) => {
                 referenceData: $referenceData
                 aggregation: $aggregation
                 contextFilters: $contextFilters
-                referenceDataVariables: $referenceDataVariables
+                queryParams: $queryParams
                 first: $first
                 at: $at
               )
@@ -375,7 +373,7 @@ router.post('/feature', async (req, res) => {
             referenceData: referenceData._id,
             aggregation: aggregation,
             contextFilters,
-            referenceDataVariables,
+            queryParams,
             first: 1000,
             at: at ? new Date(at) : undefined,
           };
@@ -420,7 +418,7 @@ router.post('/feature', async (req, res) => {
             (await dataSource.getReferenceDataItems(
               referenceData,
               apiConfiguration,
-              referenceDataVariables
+              queryParams
             )) || [];
           if (contextFilters && !isEmpty(contextFilters)) {
             data = data.filter((x) => filterReferenceData(x, contextFilters));

--- a/src/schema/query/referenceDataAggregation.query.ts
+++ b/src/schema/query/referenceDataAggregation.query.ts
@@ -396,7 +396,7 @@ type ReferenceDataAggregationArgs = {
   sortField?: string;
   sortOrder?: string;
   contextFilters?: CompositeFilterDescriptor;
-  referenceDataVariables: any;
+  queryParams: any;
 };
 
 /**
@@ -411,7 +411,7 @@ export default {
     pipeline: { type: GraphQLJSON },
     sourceFields: { type: GraphQLJSON },
     contextFilters: { type: GraphQLJSON },
-    referenceDataVariables: { type: GraphQLJSON },
+    queryParams: { type: GraphQLJSON },
     mapping: { type: GraphQLJSON },
     first: { type: GraphQLInt },
     skip: { type: GraphQLInt },
@@ -463,7 +463,7 @@ export default {
               (await dataSource.getReferenceDataItems(
                 referenceData,
                 referenceData.apiConfiguration as any,
-                args.referenceDataVariables
+                args.queryParams
               )) || [];
           }
           const transformer = new DataTransformer(

--- a/src/schema/query/referenceDataAggregation.query.ts
+++ b/src/schema/query/referenceDataAggregation.query.ts
@@ -396,7 +396,7 @@ type ReferenceDataAggregationArgs = {
   sortField?: string;
   sortOrder?: string;
   contextFilters?: CompositeFilterDescriptor;
-  graphQLVariables: any;
+  referenceDataVariables: any;
 };
 
 /**
@@ -411,7 +411,7 @@ export default {
     pipeline: { type: GraphQLJSON },
     sourceFields: { type: GraphQLJSON },
     contextFilters: { type: GraphQLJSON },
-    graphQLVariables: { type: GraphQLJSON },
+    referenceDataVariables: { type: GraphQLJSON },
     mapping: { type: GraphQLJSON },
     first: { type: GraphQLInt },
     skip: { type: GraphQLInt },
@@ -463,7 +463,7 @@ export default {
               (await dataSource.getReferenceDataItems(
                 referenceData,
                 referenceData.apiConfiguration as any,
-                args.graphQLVariables
+                args.referenceDataVariables
               )) || [];
           }
           const transformer = new DataTransformer(

--- a/src/server/apollo/dataSources.ts
+++ b/src/server/apollo/dataSources.ts
@@ -175,6 +175,7 @@ export class CustomAPI extends RESTDataSource {
     queryParams?: any
   ): Promise<any[]> {
     switch (referenceData.type) {
+      // GraphQL reference data
       case referenceDataType.graphql: {
         // Call memoized function to save external requests.
         return this.memoizedReferenceDataGraphQLItems(
@@ -183,6 +184,7 @@ export class CustomAPI extends RESTDataSource {
           queryParams
         );
       }
+      // REST reference data
       case referenceDataType.rest: {
         let url = `${apiConfiguration.endpoint.replace(/\$/, '')}/${
           referenceData.query
@@ -204,12 +206,15 @@ export class CustomAPI extends RESTDataSource {
             url = `${url}?${queryString}`;
           }
         }
+        // Fetch data from url
         const data = await this.get(url);
         return referenceData.path
           ? jsonpath.query(data, referenceData.path)
           : data;
       }
+      // Static reference data
       case referenceDataType.static: {
+        // Data is stored in model
         return referenceData.data;
       }
     }

--- a/src/server/apollo/dataSources.ts
+++ b/src/server/apollo/dataSources.ts
@@ -166,13 +166,13 @@ export class CustomAPI extends RESTDataSource {
    *
    * @param referenceData ReferenceData to fetch
    * @param apiConfiguration ApiConfiguration to use
-   * @param variables supplementary graphQL variables
+   * @param queryParams supplementary query params
    * @returns referenceData objects
    */
   async getReferenceDataItems(
     referenceData: ReferenceData,
     apiConfiguration: ApiConfiguration,
-    variables?: any
+    queryParams?: any
   ): Promise<any[]> {
     switch (referenceData.type) {
       case referenceDataType.graphql: {
@@ -180,20 +180,20 @@ export class CustomAPI extends RESTDataSource {
         return this.memoizedReferenceDataGraphQLItems(
           referenceData,
           apiConfiguration,
-          variables
+          queryParams
         );
       }
       case referenceDataType.rest: {
         let url = `${apiConfiguration.endpoint.replace(/\$/, '')}/${
           referenceData.query
         }`.replace(/([^:]\/)\/+/g, '$1');
-        if (variables && !isEmpty(variables)) {
+        if (queryParams && !isEmpty(queryParams)) {
           // Transform the variables object into a string linked by '&'
-          const queryString = Object.keys(variables)
+          const queryString = Object.keys(queryParams)
             .map(
               (key) =>
                 `${encodeURIComponent(key)}=${encodeURIComponent(
-                  variables[key]
+                  queryParams[key]
                 )}`
             )
             .join('&');


### PR DESCRIPTION
# Description
Update reference data of type rest methods to include params, adding them to the end of the URL like `<main-endpoint>?<query-param1>&<query-param2>&etc`
## Useful links

- Please insert link to ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/93130
- Please insert link to front-end branch if any: https://github.com/ReliefApplications/ems-frontend/pull/2539

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
