### PR TITLE
fix/AB#91893_Webjob-failing-when-there-is-no-record-to-insert

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -312,7 +312,8 @@
 		"upload": {
 			"errors": {
 				"invalidUserUpload": "Please provide email and role for each user.",
-				"missingFile": "No file detected."
+				"missingFile": "No file detected.",
+				"noRecordsToInsert": "No records were received for insertion."
 			}
 		}
 	},

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -313,7 +313,7 @@
 			"errors": {
 				"invalidUserUpload": "Please provide email and role for each user.",
 				"missingFile": "No file detected.",
-				"noRecordsToInsert": "No records were received for insertion."
+				"noRecordsToInsert": "No records were provided for insertion."
 			}
 		}
 	},

--- a/src/i18n/test.json
+++ b/src/i18n/test.json
@@ -312,7 +312,8 @@
 		"upload": {
 			"errors": {
 				"invalidUserUpload": "******",
-				"missingFile": "******"
+				"missingFile": "******",
+				"noRecordsToInsert": "******"
 			}
 		}
 	},

--- a/src/routes/upload/index.ts
+++ b/src/routes/upload/index.ts
@@ -219,6 +219,11 @@ router.post('/resource/records/:id', async (req: any, res) => {
  */
 router.post('/resource/insert', async (req: any, res) => {
   try {
+    if (req.body.records.length < 1) {
+      return res
+        .status(200)
+        .send(req.t('routes.upload.errors.noRecordsToInsert'));
+    }
     const authToken = req.headers.authorization.split(' ')[1];
     const decodedToken = jwtDecode(authToken) as any;
 


### PR DESCRIPTION
# Description

Added a check on the records array length
If empty, return answer and 200 response code
I think it's better this way than skipping at the webjob-level. We use 1 request per minute in any case but the backend shows that it received the information and webjob too.

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/91893)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Sent a normal list of records, got answer that 1 record was inserted
- [x] Sent an empty list of records, received correct answer that no record was to be inserted.

## Screenshots

![image](https://github.com/ReliefApplications/ems-backend/assets/80319175/365a5dfe-72da-4b0a-80a7-98e31ef6d930)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [x] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
