### PR TITLE
Bug/ab#95674 - Deleting resource breaks schema

### DIFF
--- a/src/schema/mutation/deleteForm.mutation.ts
+++ b/src/schema/mutation/deleteForm.mutation.ts
@@ -45,6 +45,10 @@ export default {
         await Resource.deleteOne({ _id: form.resource });
       } else {
         await form.deleteOne();
+        // Trick the change stream, by updating the resource
+        const resource = await Resource.findById(form.resource).select('name');
+        resource.markModified('modifiedAt');
+        await resource.save();
       }
       return form;
     } catch (err) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -29,6 +29,7 @@ import {
 } from './apollo/queries/introspection.query';
 import { pluralize } from 'inflection';
 import config from 'config';
+import { isEqual } from 'lodash';
 
 /** List of user fields */
 const USER_FIELDS = ['id', 'name', 'username'];
@@ -107,7 +108,7 @@ class SafeServer {
         this.update();
       }
       if (data.operationType === 'update') {
-        // When a form is updated, only reload schema if name, structure or status were updated
+        // When a resource is updated, only reload if fields are updated
         const fieldsThatRequireSchemaUpdate = ['fields'];
         const updatedDocFields = Object.keys(
           data.updateDescription.updatedFields
@@ -119,7 +120,8 @@ class SafeServer {
               data.updateDescription.updatedFields[f].some(
                 (field) => field.isCalculated === true
               )
-          )
+          ) ||
+          isEqual(updatedDocFields, ['modifiedAt']) // we only edit the modification date, if we delete a non-core form
         ) {
           this.update();
         }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -57,7 +57,7 @@ class SafeServer {
   /** Adds listeners to relevant collections in order to rebuild schema */
   constructor() {
     Form.watch().on('change', (data) => {
-      if (data.operationType === 'insert' || data.operationType === 'delete') {
+      if (data.operationType === 'insert') {
         // Reload schema on new form or form deletion
         this.update();
       } else if (data.operationType === 'update') {
@@ -102,6 +102,10 @@ class SafeServer {
 
     // All resource changes require schema update
     Resource.watch().on('change', (data) => {
+      if (data.operationType === 'delete') {
+        // Reload schema on resource deletion
+        this.update();
+      }
       if (data.operationType === 'update') {
         // When a form is updated, only reload schema if name, structure or status were updated
         const fieldsThatRequireSchemaUpdate = ['fields'];


### PR DESCRIPTION
# Description

Upon deleting a resource or a form that is core of a resource, an error would arise on the log (query defined in resolvers, but not in schema) and this would break grid queries.
I believe the problem is that when a resource or a core form is deleted, the Form.watch() listener in `ems-backend/src/server/index.ts` is triggered, causing a problematic schema update, and then the Resource.watch() listener is triggered, causing a normal schema update. I thought about changing the order in which those are triggered or to prevent Form.watch() from being triggered on resource deletion but I couldn't find any easy solutions to that.
The solution I found was to move the schema update call to the Resource.watch() listener and remove it from the Form.watch() listener, since it would already be called in the first one for all core forms. This removes the schema update when you delete a non-core form, but I didn't find any trouble with that.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20Core/Stories/?workitem=95674

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested creating and deleting resources, forms and non-core forms. The schema updates on all deletions except the non-core form deletions but that does not seem to break grid queries.

# Checklist:

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [x] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
