### PR TITLE
AB#90518 Email notifications data fix

### DIFF
--- a/src/schema/types/emailNotification.type.ts
+++ b/src/schema/types/emailNotification.type.ts
@@ -83,7 +83,9 @@ export const DatasetType = new GraphQLObjectType({
                   const project = mergeArrayOfObjects(nestedFields[key]) ?? {};
                   Object.assign(project, { _id: 0 });
                   const record = await Record.findById(value, project);
-                  data[key] = record;
+                  if (record) {
+                    data[key] = record;
+                  }
                 }
                 if (dropdownFields) {
                   const thisDropdownField = dropdownFields.find((field) => {


### PR DESCRIPTION
# Description

- Fixed Data displaying as number issues
- Also fixed issues raised by Adappt QA


[Related Frontend PR Link](https://github.com/ReliefApplications/ems-frontend/pull/2611)

## Tickets

- [ ] https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/90518/

## Other Issues Fixed

- [ ] Existing Email notification template - Newly created records are not showing up in preview
- [ ] When editing existing email notification (send email) - only 10 records are visible. (now shows up to 50)
- [ ] The Preview and apply filter button in the DL page for Select with filter is now working and not showing in other steps
- [ ] Radio Nuclear not displaying in multiselect

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)



