### PR TITLE
feat/AB#104720_EIS-implement-add-record-action-of-dashboard-buttons

### DIFF
--- a/src/models/dashboard.model.ts
+++ b/src/models/dashboard.model.ts
@@ -4,12 +4,15 @@ import mongoose, { Schema, Document } from 'mongoose';
 /** Mongoose button interface declaration */
 export interface Button {
   text: string;
-  href: string;
+  href?: string;
   hasRoleRestriction: boolean;
   roles: string[];
   variant: string;
   category: string;
   openInNewTab: boolean;
+  resource?: string;
+  template?: string;
+  recordFields?: string[];
 }
 
 /** Dashboard filter interface declaration */
@@ -47,6 +50,9 @@ const buttonSchema = new Schema<Button>(
     variant: String,
     category: String,
     openInNewTab: Boolean,
+    resource: String,
+    template: String,
+    recordFields: Array<string>,
   },
   { _id: false }
 );

--- a/src/schema/inputs/button-action.input.ts
+++ b/src/schema/inputs/button-action.input.ts
@@ -11,7 +11,7 @@ const ButtonActionInputType = new GraphQLInputObjectType({
   name: 'ButtonActionInputType',
   fields: () => ({
     text: { type: new GraphQLNonNull(GraphQLString) },
-    href: { type: new GraphQLNonNull(GraphQLString) },
+    href: { type: GraphQLString },
     hasRoleRestriction: { type: new GraphQLNonNull(GraphQLBoolean) },
     roles: {
       type: new GraphQLList(GraphQLString),
@@ -19,6 +19,9 @@ const ButtonActionInputType = new GraphQLInputObjectType({
     variant: { type: new GraphQLNonNull(GraphQLString) },
     category: { type: new GraphQLNonNull(GraphQLString) },
     openInNewTab: { type: new GraphQLNonNull(GraphQLBoolean) },
+    resource: { type: GraphQLString },
+    template: { type: GraphQLString },
+    recordFields: { type: new GraphQLList(GraphQLString) },
   }),
 });
 

--- a/src/schema/mutation/editRecord.mutation.ts
+++ b/src/schema/mutation/editRecord.mutation.ts
@@ -63,6 +63,7 @@ type EditRecordArgs = {
   template?: string | Types.ObjectId;
   lang?: string;
   draft?: boolean;
+  skipValidation: boolean;
 };
 
 /**
@@ -78,6 +79,7 @@ export default {
     template: { type: GraphQLID },
     lang: { type: GraphQLString },
     draft: { type: GraphQLBoolean },
+    skipValidation: { type: GraphQLBoolean, defaultValue: false },
   },
   async resolve(parent, args: EditRecordArgs, context: Context) {
     // Authentication check
@@ -138,7 +140,7 @@ export default {
       } catch (err) {
         logger.error(err.message, { stack: err.stack });
       }
-      if (validationErrors && validationErrors.length) {
+      if (validationErrors.length && !args.skipValidation) {
         return Object.assign(oldRecord, { validationErrors });
       }
       // Generate new version, from current data


### PR DESCRIPTION
# Description

feat: integrate resource, template and record fields properties for action buttons in dashboard

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/104720)
- [Link to front-end branch](https://github.com/ReliefApplications/ems-frontend/pull/2663)
- Please insert any useful link ( documentation you used for example )

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
