### PR TITLE
Feat/AB#104943 Add option to evaluate records expressions when inserted via webjob

### DIFF
--- a/src/routes/upload/index.ts
+++ b/src/routes/upload/index.ts
@@ -229,13 +229,17 @@ router.post('/resource/insert', async (req: any, res) => {
     const authToken = req.headers.authorization.split(' ')[1];
     const decodedToken = jwtDecode(authToken) as any;
 
+    const evaluateExpressions =
+      req.body.parameters.evaluateExpressions || false;
+
     // Block if connected with user to Service
     if (!decodedToken.email && !decodedToken.name) {
       const insertRecordsMessage = await insertRecordsPulljob(
         req.body.records,
         req.body.parameters,
         true,
-        true
+        true,
+        evaluateExpressions
       );
       return res.status(200).send(insertRecordsMessage);
     }

--- a/src/server/pullJobScheduler.ts
+++ b/src/server/pullJobScheduler.ts
@@ -317,12 +317,14 @@ const getUserRoleFiltersFromApp = (appName: string): any => {
  * @param pullJob pull job configuration
  * @param isEIOS is EIOS pulljob or not
  * @param fromRoute tells if the insertion is done from pull-job or route
+ * @param evaluateExpressions ask the backend to evaluate record expressions like defaultValueExpression
  */
 export const insertRecords = async (
   data: any[],
   pullJob: PullJob,
   isEIOS = false,
-  fromRoute?: boolean
+  fromRoute = false,
+  evaluateExpressions = false
 ): Promise<string> => {
   const form = await Form.findById(pullJob.convertTo);
   if (!form) {
@@ -557,10 +559,12 @@ export const insertRecords = async (
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       record = await setSpecialFields(record);
 
-      // Force the activation of form's fields triggers
-      const updatedRecord = checkRecordExpressions(record, survey);
+      if (evaluateExpressions) {
+        // Force the activation of form's fields expressions
+        record = checkRecordExpressions(record, survey);
+      }
 
-      records.push(updatedRecord);
+      records.push(record);
     }
   }
   let insertReportMessage = '';

--- a/src/utils/form/checkRecordExpressions.ts
+++ b/src/utils/form/checkRecordExpressions.ts
@@ -1,0 +1,25 @@
+import { Record } from '@models';
+import * as Survey from 'survey-knockout';
+
+/**
+ * Force the evaluation of record expressions
+ *
+ * @param record edited record
+ * @param survey survey instance from record's form
+ * @returns Updated record data
+ */
+export const checkRecordExpressions = (
+  record: Record,
+  survey: Survey.Survey
+): Record => {
+  // Fill the survey data with current record data to allow expressions to fetch values of other questions.
+  survey.data = { ...survey.data, ...record.data };
+
+  // Setting this variable forces the expressions to evaluate. It has not other purpose.
+  survey.setVariable('__forcingExpressionsEvaluation', 1);
+
+  record.data = survey.data;
+  return record;
+};
+
+export default checkRecordExpressions;

--- a/src/utils/form/index.ts
+++ b/src/utils/form/index.ts
@@ -14,3 +14,4 @@ export * from './getDisplayText';
 export * from './checkRecordValidation';
 export * from './getAccessibleFields';
 export * from './checkRecordTriggers';
+export * from './checkRecordExpressions';


### PR DESCRIPTION
# Description

When inserting records through a (legacy) pulljob or a webjob, the logic defaultValueExpression won't be evaluated. This PR adds an option as a req.data.parameter variable to enable the expression of such logic.


/!\ Here is a reference for the use of "survey.setVariable('__forcingExpressionsEvaluation', 1)" :
https://github.com/surveyjs/survey-library/issues/7694
Since "survey.runExpressions()" didn't seem available in the current version, I used the workaround.

## Useful links

- [Link to ticket](https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/104943)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactor or addition to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Inserted records through webjob and sending the variable as "true"
- [x] Inserted records through webjob and sending the variable as "false"
- [x] Inserted records through webjob without sending the variable

## Screenshots

Skipped since it's backend changes

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
