### PR TITLE
feat/AB-DL-CRUD Implementation

### DIFF
--- a/src/schema/mutation/deleteEmailDistributionList.mutation.ts
+++ b/src/schema/mutation/deleteEmailDistributionList.mutation.ts
@@ -1,0 +1,63 @@
+import { GraphQLError, GraphQLNonNull, GraphQLID } from 'graphql';
+import { logger } from '@services/logger.service';
+import { graphQLAuthCheck } from '@schema/shared';
+import { Context } from '@server/apollo/context';
+import { EmailDistributionList, EmailNotification } from '@models';
+import { EmailDistributionListType } from '@schema/types/emailDistribution.type';
+import extendAbilityForApplications from '@security/extendAbilityForApplication';
+import { AppAbility } from '@security/defineUserAbility';
+
+/**
+ * Mutation to delete an existing distribution list.
+ */
+export default {
+  type: EmailDistributionListType,
+  args: {
+    id: { type: new GraphQLNonNull(GraphQLID) },
+  },
+  async resolve(_, { id }, context: Context) {
+    graphQLAuthCheck(context);
+
+    try {
+      const distributionList = await EmailDistributionList.findOne({
+        _id: id,
+        isDeleted: 0,
+      });
+
+      if (!distributionList) {
+        throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));
+      }
+
+      const user = context.user;
+      const ability: AppAbility = extendAbilityForApplications(
+        user,
+        distributionList.applicationId.toString()
+      );
+
+      if (ability.cannot('delete', 'DistributionList')) {
+        throw new GraphQLError(
+          context.i18next.t('common.errors.permissionNotGranted')
+        );
+      }
+
+      // Unset the reference in any EmailNotifications using this distribution list
+      await EmailNotification.updateMany(
+        { emailDistributionList: distributionList._id },
+        { $unset: { emailDistributionList: 1 } }
+      );
+
+      // Delete DL
+      await distributionList.deleteOne();
+
+      return distributionList;
+    } catch (err) {
+      logger.error(err.message, { stack: err.stack });
+      if (err instanceof GraphQLError) {
+        throw new GraphQLError(err.message);
+      }
+      throw new GraphQLError(
+        context.i18next.t('common.errors.internalServerError')
+      );
+    }
+  },
+};

--- a/src/schema/mutation/deleteEmailDistributionList.mutation.ts
+++ b/src/schema/mutation/deleteEmailDistributionList.mutation.ts
@@ -34,7 +34,7 @@ export default {
         distributionList.applicationId.toString()
       );
 
-      if (ability.cannot('delete', 'DistributionList')) {
+      if (ability.cannot('update', 'EmailNotification')) {
         throw new GraphQLError(
           context.i18next.t('common.errors.permissionNotGranted')
         );

--- a/src/schema/mutation/deleteEmailNotification.mutation.ts
+++ b/src/schema/mutation/deleteEmailNotification.mutation.ts
@@ -15,6 +15,7 @@ import { Types } from 'mongoose';
 import { Context } from '@server/apollo/context';
 import extendAbilityForApplications from '@security/extendAbilityForApplication';
 import { CustomTemplate } from '@models/customTemplate.model';
+import { deleteFile } from '@utils/notification/util';
 
 /** Arguments for the deleteEmailNotification mutation */
 type DeleteEmailNotificationArgs = {
@@ -60,6 +61,7 @@ export default {
           _id: args.id,
           applicationId: args.applicationId,
         });
+        await deleteFile(emailNotification.attachments, context);
       } else {
         // Handle cases where the user has limited permissions
         const accessibleEmailNotification = await EmailNotification.findOne({
@@ -73,6 +75,7 @@ export default {
             _id: args.id,
             applicationId: args.applicationId,
           });
+          await deleteFile(emailNotification.attachments, context);
         }
       }
 

--- a/src/schema/mutation/index.ts
+++ b/src/schema/mutation/index.ts
@@ -96,6 +96,7 @@ import editEmailDistributionList from './editEmailDistributionList.mutation';
 import addCustomTemplate from './addCustomTemplate.mutation';
 import editCustomTemplate from './editCustomTemplate.mutation';
 import deleteEmailNotification from './deleteEmailNotification.mutation';
+import deleteEmailDistributionList from './deleteEmailDistributionList.mutation';
 
 /** GraphQL mutation definition */
 const Mutation = new GraphQLObjectType({
@@ -198,6 +199,7 @@ const Mutation = new GraphQLObjectType({
     deleteDashboardTemplates,
     editCustomTemplate,
     deleteEmailNotification,
+    deleteEmailDistributionList,
   },
 });
 

--- a/src/utils/notification/util.ts
+++ b/src/utils/notification/util.ts
@@ -1,3 +1,9 @@
+import { EmailNotificationAttachment } from '@models/emailNotification.model';
+import { Context } from '@server/apollo/context';
+import { logger } from '@services/logger.service';
+import axios from 'axios';
+import config from 'config';
+
 /**
  * Returns headers required for Azure Function
  *
@@ -13,3 +19,46 @@ export const azureFunctionHeaders = (req: any) => {
     }),
   };
 };
+
+/**
+ * Deletes files from document management
+ *
+ * @param attachments - attachment details, including file info and whether to send as an attachment.
+ * @param context - context from GraphQL resolver, used to get accesstoken
+ * @returns promise that resolves when the files have been deleted.
+ */
+export async function deleteFile(
+  attachments: EmailNotificationAttachment,
+  context: Context
+) {
+  if (
+    !attachments.files ||
+    attachments.files.length === 0 ||
+    !context.accesstoken
+  ) {
+    return;
+  }
+
+  const attachmentRequests = attachments.files.map(async (file) => {
+    const { driveId, itemId, fileName } = file;
+
+    try {
+      if (attachments.sendAsAttachment) {
+        await axios.delete(
+          `${config.get(
+            'commonServices.url'
+          )}/documents/drives/${driveId}/items/${itemId}`,
+          {
+            headers: {
+              Authorization: `Bearer ${context.accesstoken}`,
+            },
+          }
+        );
+      }
+    } catch (error) {
+      logger.error(`Failed to delete file: ${fileName}`, error.message);
+    }
+  });
+
+  await Promise.all(attachmentRequests);
+}


### PR DESCRIPTION
# Description

## New Feat: DL CRUD
* To accommodate the frontend changes for DL CRUD, a new `deleteEmailDistributionList` mutation has been written. 

## Fix: File attachments are now deleted from the document management system when a draft email notification has been deleted
* When an email notification with files is deleted, the files are now removed from the document manage system. This handles the case when a drafted email notification is deleted. 

# Useful links

- Frontend PR: https://github.com/ReliefApplications/ems-frontend/pull/2768
- Function PR: https://dev.azure.com/WHOHQ/EMSSAFE/_git/emssafe-emailfunction/pullrequest/20329

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)