### PR TITLE
AB#121668 - Enable menu and account on one line, and icon-only menu items

### DIFF
--- a/src/models/application.model.ts
+++ b/src/models/application.model.ts
@@ -25,6 +25,7 @@ export interface Application extends Document {
   modifiedAt: Date;
   description?: string;
   sideMenu?: boolean;
+  topMenu?: boolean;
   hideMenu?: boolean;
   status?: any;
   createdBy?: mongoose.Types.ObjectId;
@@ -75,6 +76,7 @@ const applicationSchema = new Schema<Application>(
     settings: mongoose.Schema.Types.Mixed,
     description: String,
     sideMenu: Boolean,
+    topMenu: Boolean,
     hideMenu: Boolean,
     permissions: {
       canSee: [

--- a/src/models/page.model.ts
+++ b/src/models/page.model.ts
@@ -31,7 +31,10 @@ export interface Page extends Document {
   name: string;
   icon: string;
   showName?: boolean;
-  showIcon?: boolean;
+  navBar?: {
+    showName?: boolean;
+    showIcon?: boolean;
+  };
   createdAt: Date;
   modifiedAt: Date;
   type: string;
@@ -65,9 +68,15 @@ const pageSchema = new Schema<Page>(
     name: String,
     icon: String,
     showName: Boolean,
-    showIcon: {
-      type: Boolean,
-      default: true,
+    navBar: {
+      showName: {
+        type: Boolean,
+        default: true,
+      },
+      showIcon: {
+        type: Boolean,
+        default: true,
+      },
     },
     type: {
       type: String,

--- a/src/models/page.model.ts
+++ b/src/models/page.model.ts
@@ -31,6 +31,7 @@ export interface Page extends Document {
   name: string;
   icon: string;
   showName?: boolean;
+  showIcon?: boolean;
   createdAt: Date;
   modifiedAt: Date;
   type: string;
@@ -64,6 +65,10 @@ const pageSchema = new Schema<Page>(
     name: String,
     icon: String,
     showName: Boolean,
+    showIcon: {
+      type: Boolean,
+      default: true,
+    },
     type: {
       type: String,
       enum: Object.values(contentType),

--- a/src/models/step.model.ts
+++ b/src/models/step.model.ts
@@ -12,6 +12,7 @@ export interface Step extends Document {
   name: string;
   icon: string;
   showName?: boolean;
+  showIcon?: boolean;
   createdAt: Date;
   modifiedAt: Date;
   type: string;
@@ -35,6 +36,10 @@ const stepSchema = new Schema<Step>(
     name: String,
     icon: String,
     showName: Boolean,
+    showIcon: {
+      type: Boolean,
+      default: true,
+    },
     type: {
       type: String,
       enum: Object.values(contentType),

--- a/src/models/step.model.ts
+++ b/src/models/step.model.ts
@@ -12,7 +12,10 @@ export interface Step extends Document {
   name: string;
   icon: string;
   showName?: boolean;
-  showIcon?: boolean;
+  navBar?: {
+    showName?: boolean;
+    showIcon?: boolean;
+  };
   createdAt: Date;
   modifiedAt: Date;
   type: string;
@@ -36,9 +39,15 @@ const stepSchema = new Schema<Step>(
     name: String,
     icon: String,
     showName: Boolean,
-    showIcon: {
-      type: Boolean,
-      default: true,
+    navBar: {
+      showName: {
+        type: Boolean,
+        default: true,
+      },
+      showIcon: {
+        type: Boolean,
+        default: true,
+      },
     },
     type: {
       type: String,

--- a/src/schema/inputs/navBarSettings.input.ts
+++ b/src/schema/inputs/navBarSettings.input.ts
@@ -1,0 +1,16 @@
+import {
+  GraphQLBoolean,
+  GraphQLInputObjectType,
+  GraphQLNonNull,
+} from 'graphql';
+
+/**
+ * Nav Bar settings input type definition
+ */
+export const NavBarSettingsInputType = new GraphQLInputObjectType({
+  name: 'NavBarSettingsInputType',
+  fields: () => ({
+    showName: { type: new GraphQLNonNull(GraphQLBoolean) },
+    showIcon: { type: new GraphQLNonNull(GraphQLBoolean) },
+  }),
+});

--- a/src/schema/mutation/duplicateApplication.mutation.ts
+++ b/src/schema/mutation/duplicateApplication.mutation.ts
@@ -88,6 +88,7 @@ export default {
             name: args.name,
             description: baseApplication.description,
             sideMenu: baseApplication.sideMenu,
+            topMenu: baseApplication.topMenu,
             hideMenu: baseApplication.hideMenu,
             status: status.pending,
             createdBy: user._id,

--- a/src/schema/mutation/editApplication.mutation.ts
+++ b/src/schema/mutation/editApplication.mutation.ts
@@ -119,23 +119,6 @@ export default {
       if (!isNil(args.shortcut) && args.shortcut !== '') {
         await validateShortcut(args.id, args.shortcut);
       }
-      const nextTopMenu = !isNil(args.topMenu)
-        ? args.topMenu
-        : application.topMenu ?? false;
-      const nextSideMenu = !isNil(args.sideMenu)
-        ? args.sideMenu
-        : application.sideMenu ?? true;
-      let enforcedTopMenu = nextTopMenu;
-      let enforcedSideMenu = nextSideMenu;
-      if (nextTopMenu && nextSideMenu) {
-        if (!isNil(args.topMenu)) {
-          enforcedSideMenu = false;
-        } else if (!isNil(args.sideMenu)) {
-          enforcedTopMenu = false;
-        } else {
-          enforcedSideMenu = false;
-        }
-      }
 
       Object.assign(
         update,
@@ -145,16 +128,12 @@ export default {
         args.pages && { pages: args.pages },
         args.settings && { settings: args.settings },
         args.permissions && { permissions: args.permissions },
+        !isNil(args.sideMenu) && { sideMenu: args.sideMenu },
+        !isNil(args.topMenu) && { topMenu: args.topMenu },
         !isNil(args.hideMenu) && { hideMenu: args.hideMenu },
         !isNil(args.shortcut) && { shortcut: args.shortcut }
       );
 
-      if (!isNil(args.sideMenu) || nextSideMenu !== application.sideMenu) {
-        Object.assign(update, { sideMenu: enforcedSideMenu });
-      }
-      if (!isNil(args.topMenu) || nextTopMenu !== application.topMenu) {
-        Object.assign(update, { topMenu: enforcedTopMenu });
-      }
       application = await Application.findOneAndUpdate(filters, update, {
         new: true,
       });

--- a/src/schema/mutation/editApplication.mutation.ts
+++ b/src/schema/mutation/editApplication.mutation.ts
@@ -25,6 +25,7 @@ type EditApplicationArgs = {
   id: string | Types.ObjectId;
   description?: string;
   sideMenu?: boolean;
+  topMenu?: boolean;
   hideMenu?: boolean;
   name?: string;
   status?: StatusType;
@@ -72,6 +73,7 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
     description: { type: GraphQLString },
     sideMenu: { type: GraphQLBoolean },
+    topMenu: { type: GraphQLBoolean },
     hideMenu: { type: GraphQLBoolean },
     name: { type: GraphQLString },
     status: { type: StatusEnumType },
@@ -117,6 +119,24 @@ export default {
       if (!isNil(args.shortcut) && args.shortcut !== '') {
         await validateShortcut(args.id, args.shortcut);
       }
+      const nextTopMenu = !isNil(args.topMenu)
+        ? args.topMenu
+        : application.topMenu ?? false;
+      const nextSideMenu = !isNil(args.sideMenu)
+        ? args.sideMenu
+        : application.sideMenu ?? true;
+      let enforcedTopMenu = nextTopMenu;
+      let enforcedSideMenu = nextSideMenu;
+      if (nextTopMenu && nextSideMenu) {
+        if (!isNil(args.topMenu)) {
+          enforcedSideMenu = false;
+        } else if (!isNil(args.sideMenu)) {
+          enforcedTopMenu = false;
+        } else {
+          enforcedSideMenu = false;
+        }
+      }
+
       Object.assign(
         update,
         args.name && { name: args.name },
@@ -125,10 +145,16 @@ export default {
         args.pages && { pages: args.pages },
         args.settings && { settings: args.settings },
         args.permissions && { permissions: args.permissions },
-        !isNil(args.sideMenu) && { sideMenu: args.sideMenu },
         !isNil(args.hideMenu) && { hideMenu: args.hideMenu },
         !isNil(args.shortcut) && { shortcut: args.shortcut }
       );
+
+      if (!isNil(args.sideMenu) || nextSideMenu !== application.sideMenu) {
+        Object.assign(update, { sideMenu: enforcedSideMenu });
+      }
+      if (!isNil(args.topMenu) || nextTopMenu !== application.topMenu) {
+        Object.assign(update, { topMenu: enforcedTopMenu });
+      }
       application = await Application.findOneAndUpdate(filters, update, {
         new: true,
       });

--- a/src/schema/mutation/editPage.mutation.ts
+++ b/src/schema/mutation/editPage.mutation.ts
@@ -97,7 +97,7 @@ export default {
       // Create update
       const update = {
         ...(args.name && { name: args.name }),
-        ...(args.icon && { icon: args.icon }),
+        ...(has(args, 'icon') && { icon: args.icon }),
         ...(has(args, 'showName') && { showName: args.showName }),
         ...(args.navBar && { navBar: args.navBar }),
       } as any;

--- a/src/schema/mutation/editPage.mutation.ts
+++ b/src/schema/mutation/editPage.mutation.ts
@@ -17,6 +17,7 @@ import GraphQLJSON from 'graphql-type-json';
 import { cloneDeep, has, isArray, isEmpty, isNil, omit } from 'lodash';
 import { Types } from 'mongoose';
 import { PageType } from '../types';
+import { NavBarSettingsInputType } from '@schema/inputs/navBarSettings.input';
 
 /** Simple form permission change type */
 type SimplePermissionChange =
@@ -38,7 +39,10 @@ export type EditPageArgs = {
   id: string | Types.ObjectId;
   name?: string;
   showName?: boolean;
-  showIcon?: boolean;
+  navBar?: {
+    showName?: boolean;
+    showIcon?: boolean;
+  };
   permissions?: any;
   icon?: string;
   visible?: boolean;
@@ -56,7 +60,7 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
     name: { type: GraphQLString },
     showName: { type: GraphQLBoolean },
-    showIcon: { type: GraphQLBoolean },
+    navBar: { type: NavBarSettingsInputType },
     icon: { type: GraphQLString },
     permissions: { type: GraphQLJSON },
     visible: { type: GraphQLBoolean },
@@ -95,7 +99,7 @@ export default {
         ...(args.name && { name: args.name }),
         ...(args.icon && { icon: args.icon }),
         ...(has(args, 'showName') && { showName: args.showName }),
-        ...(has(args, 'showIcon') && { showIcon: args.showIcon }),
+        ...(args.navBar && { navBar: args.navBar }),
       } as any;
       // Update buttons
       if (args.buttons) {

--- a/src/schema/mutation/editPage.mutation.ts
+++ b/src/schema/mutation/editPage.mutation.ts
@@ -38,6 +38,7 @@ export type EditPageArgs = {
   id: string | Types.ObjectId;
   name?: string;
   showName?: boolean;
+  showIcon?: boolean;
   permissions?: any;
   icon?: string;
   visible?: boolean;
@@ -55,6 +56,7 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
     name: { type: GraphQLString },
     showName: { type: GraphQLBoolean },
+    showIcon: { type: GraphQLBoolean },
     icon: { type: GraphQLString },
     permissions: { type: GraphQLJSON },
     visible: { type: GraphQLBoolean },
@@ -93,6 +95,7 @@ export default {
         ...(args.name && { name: args.name }),
         ...(args.icon && { icon: args.icon }),
         ...(has(args, 'showName') && { showName: args.showName }),
+        ...(has(args, 'showIcon') && { showIcon: args.showIcon }),
       } as any;
       // Update buttons
       if (args.buttons) {

--- a/src/schema/mutation/editStep.mutation.ts
+++ b/src/schema/mutation/editStep.mutation.ts
@@ -111,7 +111,7 @@ export default {
       // Create update
       const update = {
         ...(args.name && { name: args.name }),
-        ...(args.icon && { icon: args.icon }),
+        ...(has(args, 'icon') && { icon: args.icon }),
         ...(args.type && { type: args.type }),
         ...(args.content && { content: args.content }),
         ...(has(args, 'showName') && { showName: args.showName }),

--- a/src/schema/mutation/editStep.mutation.ts
+++ b/src/schema/mutation/editStep.mutation.ts
@@ -38,6 +38,7 @@ type EditStepArgs = {
   id: string | Types.ObjectId;
   name?: string;
   showName?: boolean;
+  showIcon?: boolean;
   type?: string;
   content?: string | Types.ObjectId;
   permissions?: any;
@@ -55,6 +56,7 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
     name: { type: GraphQLString },
     showName: { type: GraphQLBoolean },
+    showIcon: { type: GraphQLBoolean },
     icon: { type: GraphQLString },
     type: { type: GraphQLString },
     content: { type: GraphQLID },
@@ -109,6 +111,7 @@ export default {
         ...(args.type && { type: args.type }),
         ...(args.content && { content: args.content }),
         ...(has(args, 'showName') && { showName: args.showName }),
+        ...(has(args, 'showIcon') && { showIcon: args.showIcon }),
       } as any;
       // Update buttons
       if (args.buttons) {

--- a/src/schema/mutation/editStep.mutation.ts
+++ b/src/schema/mutation/editStep.mutation.ts
@@ -17,6 +17,7 @@ import GraphQLJSON from 'graphql-type-json';
 import { cloneDeep, has, isArray, isEmpty, omit } from 'lodash';
 import { Types } from 'mongoose';
 import { StepType } from '../types';
+import { NavBarSettingsInputType } from '@schema/inputs/navBarSettings.input';
 
 /** Simple form permission change type */
 type SimplePermissionChange =
@@ -38,7 +39,10 @@ type EditStepArgs = {
   id: string | Types.ObjectId;
   name?: string;
   showName?: boolean;
-  showIcon?: boolean;
+  navBar?: {
+    showName?: boolean;
+    showIcon?: boolean;
+  };
   type?: string;
   content?: string | Types.ObjectId;
   permissions?: any;
@@ -56,7 +60,7 @@ export default {
     id: { type: new GraphQLNonNull(GraphQLID) },
     name: { type: GraphQLString },
     showName: { type: GraphQLBoolean },
-    showIcon: { type: GraphQLBoolean },
+    navBar: { type: NavBarSettingsInputType },
     icon: { type: GraphQLString },
     type: { type: GraphQLString },
     content: { type: GraphQLID },
@@ -111,7 +115,7 @@ export default {
         ...(args.type && { type: args.type }),
         ...(args.content && { content: args.content }),
         ...(has(args, 'showName') && { showName: args.showName }),
-        ...(has(args, 'showIcon') && { showIcon: args.showIcon }),
+        ...(args.navBar && { navBar: args.navBar }),
       } as any;
       // Update buttons
       if (args.buttons) {

--- a/src/schema/types/application.type.ts
+++ b/src/schema/types/application.type.ts
@@ -79,6 +79,16 @@ export const ApplicationType = new GraphQLObjectType({
         }
       },
     },
+    topMenu: {
+      type: GraphQLBoolean,
+      resolve(parent) {
+        if (isNil(parent.topMenu)) {
+          return false;
+        } else {
+          return parent.topMenu;
+        }
+      },
+    },
     hideMenu: {
       type: GraphQLBoolean,
       resolve(parent) {

--- a/src/schema/types/navBarSettings.type.ts
+++ b/src/schema/types/navBarSettings.type.ts
@@ -1,0 +1,17 @@
+import { GraphQLBoolean, GraphQLObjectType } from 'graphql';
+
+/**
+ * GraphQL nav bar settings type definition
+ * Used in StepType and PageType
+ */
+export const NavBarSettingsType = new GraphQLObjectType({
+  name: 'NavBarSettings',
+  fields: () => ({
+    showName: {
+      type: GraphQLBoolean,
+    },
+    showIcon: {
+      type: GraphQLBoolean,
+    },
+  }),
+});

--- a/src/schema/types/page.type.ts
+++ b/src/schema/types/page.type.ts
@@ -13,8 +13,9 @@ import {
 } from 'graphql';
 import { GraphQLDate } from 'graphql-scalars';
 import GraphQLJSON from 'graphql-type-json';
-import { isNil } from 'lodash';
+import { get, isNil } from 'lodash';
 import { AccessType, ApplicationType } from '.';
+import { NavBarSettingsType } from './navBarSettings.type';
 
 /** GraphQL page type type definition */
 export const PageType = new GraphQLObjectType({
@@ -41,10 +42,15 @@ export const PageType = new GraphQLObjectType({
         return isNil(parent.showName) ? defaultShowName : parent.showName;
       },
     },
-    showIcon: {
-      type: GraphQLBoolean,
+    navBar: {
+      type: NavBarSettingsType,
       resolve(parent) {
-        return isNil(parent.showIcon) ? true : parent.showIcon;
+        if (parent.navBar) {
+          return {
+            showName: get(parent, 'navBar.showName') ?? true,
+            showIcon: get(parent, 'navBar.showIcon') ?? true,
+          };
+        }
       },
     },
     createdAt: { type: GraphQLString },

--- a/src/schema/types/page.type.ts
+++ b/src/schema/types/page.type.ts
@@ -41,6 +41,12 @@ export const PageType = new GraphQLObjectType({
         return isNil(parent.showName) ? defaultShowName : parent.showName;
       },
     },
+    showIcon: {
+      type: GraphQLBoolean,
+      resolve(parent) {
+        return isNil(parent.showIcon) ? true : parent.showIcon;
+      },
+    },
     createdAt: { type: GraphQLString },
     modifiedAt: { type: GraphQLString },
     type: { type: ContentEnumType },

--- a/src/schema/types/step.type.ts
+++ b/src/schema/types/step.type.ts
@@ -12,6 +12,8 @@ import {
 import GraphQLJSON from 'graphql-type-json';
 import isNil from 'lodash/isNil';
 import { AccessType, WorkflowType } from '.';
+import { NavBarSettingsType } from './navBarSettings.type';
+import { get } from 'lodash';
 
 /** GraphQL Step type definition */
 export const StepType = new GraphQLObjectType({
@@ -32,10 +34,15 @@ export const StepType = new GraphQLObjectType({
         return isNil(parent.showName) ? defaultShowName : parent.showName;
       },
     },
-    showIcon: {
-      type: GraphQLBoolean,
+    navBar: {
+      type: NavBarSettingsType,
       resolve(parent) {
-        return isNil(parent.showIcon) ? true : parent.showIcon;
+        if (parent.navBar) {
+          return {
+            showName: get(parent, 'navBar.showName') ?? true,
+            showIcon: get(parent, 'navBar.showIcon') ?? true,
+          };
+        }
       },
     },
     createdAt: { type: GraphQLString },

--- a/src/schema/types/step.type.ts
+++ b/src/schema/types/step.type.ts
@@ -32,6 +32,12 @@ export const StepType = new GraphQLObjectType({
         return isNil(parent.showName) ? defaultShowName : parent.showName;
       },
     },
+    showIcon: {
+      type: GraphQLBoolean,
+      resolve(parent) {
+        return isNil(parent.showIcon) ? true : parent.showIcon;
+      },
+    },
     createdAt: { type: GraphQLString },
     modifiedAt: { type: GraphQLString },
     type: { type: ContentEnumType },


### PR DESCRIPTION
Enable menu and account on one line, and icon-only menu items

# Description

This update implements a new “Show menu on the top” option that lets an application render its page's navigation directly in the header. It works seamlessly with the existing layouts: the horizontal bar below the header and the vertical side menu. The top and side menu options are mutually exclusive: turning on the top menu automatically disables the side menu and vice-versa.

Additionally, beyond the navigation layout, the update adds display controls everywhere navigation labels show up: pages and workflow steps, and tabs widget, can now show their name, their icon, or both, according to their settings. You can’t hide both name and icon at the same time.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)
- [X] This change requires a documentation update

## Screenshots

Menu Settings:

- Horizontal bar below the header:

<img width="1528" height="1029" alt="image" src="https://github.com/user-attachments/assets/4a117ce8-39ee-4afb-bbd4-c5d730ca029b" />

- Menu on the side:

<img width="1738" height="879" alt="image" src="https://github.com/user-attachments/assets/73dbc267-3d1c-42ae-913c-fb78ef1d0ba4" />

- Menu on the hearder:

<img width="1656" height="888" alt="image" src="https://github.com/user-attachments/assets/d07cdda3-953a-4832-a1a6-b52c26e06c79" />


Display Name and Icons Controls

- Both:

<img width="1203" height="1017" alt="image" src="https://github.com/user-attachments/assets/6fc6622f-9083-47b9-9157-2ba091824d85" />

- Icon Only:

<img width="1185" height="1006" alt="image" src="https://github.com/user-attachments/assets/ae8bc756-09be-4228-b3af-4a7961d54179" />

- Name Only:

<img width="1186" height="1003" alt="image" src="https://github.com/user-attachments/assets/2667573c-3a5c-474b-94c5-93da14035180" />

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
