### PR TITLE
AB#122462 - Display only resources questions

### DIFF
--- a/src/utils/form/extractFields.ts
+++ b/src/utils/form/extractFields.ts
@@ -17,6 +17,12 @@ export const extractFields = async (object, fields, core): Promise<void> => {
       if (element.type === 'panel') {
         await extractFields(element, fields, core);
       } else {
+        if (
+          (element.type === 'resource' || element.type === 'resources') &&
+          element.displayOnly
+        ) {
+          continue;
+        }
         if (!element.valueName) {
           throw new GraphQLError(
             i18next.t('utils.form.extractFields.errors.missingDataField')

--- a/src/utils/form/extractFields.ts
+++ b/src/utils/form/extractFields.ts
@@ -17,10 +17,8 @@ export const extractFields = async (object, fields, core): Promise<void> => {
       if (element.type === 'panel') {
         await extractFields(element, fields, core);
       } else {
-        if (
-          (element.type === 'resource' || element.type === 'resources') &&
-          element.displayOnly
-        ) {
+        if (element.type === 'resources' && element.displayOnly) {
+          // Don't store as field if question is display only
           continue;
         }
         if (!element.valueName) {


### PR DESCRIPTION
# Description

Added a new "display-only" option to the “resources” question that shows a read-only grid of records without saving any. Removed the need for a "Related name" in that mode, and also hid the field. When "display-only" is enabled, the grid loads all records, applies dynamic and additional admin filters, hides the Search button, and disables row selection and actions.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [ ] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules