### PR TITLE
AB#128988 - ABC - Make context.incrementalid available

### DIFF
--- a/__tests__/utils/context/getContextData.spec.ts
+++ b/__tests__/utils/context/getContextData.spec.ts
@@ -1,0 +1,33 @@
+import mongoose from 'mongoose';
+import { Record, Resource } from '@models';
+import { getContextDataForRecord } from '@utils/context/getContextData';
+
+describe('getContextDataForRecord', () => {
+  it('includes the record incrementalId in the context data', async () => {
+    const resource = new Resource({
+      name: 'Events',
+      fields: [
+        {
+          name: 'eventSignalId',
+          type: 'text',
+        },
+      ],
+    });
+
+    const record = new Record({
+      incrementalId: '2026-D0000001',
+      form: new mongoose.Types.ObjectId(),
+      _form: new mongoose.Types.ObjectId(),
+      data: {
+        eventSignalId: 'signal-1',
+      },
+    });
+
+    const contextData = await getContextDataForRecord(resource, record, {});
+
+    expect(contextData).toEqual({
+      eventSignalId: 'signal-1',
+      incrementalId: '2026-D0000001',
+    });
+  });
+});

--- a/src/utils/context/getContextData.ts
+++ b/src/utils/context/getContextData.ts
@@ -41,7 +41,12 @@ export const getContextDataForRecord = async (
     recordID instanceof Record ? recordID : await Record.findById(recordID)
   ) as Record;
 
-  if (!resource || depth > MAX_DEPTH || !record.data) return record.data ?? {};
+  if (!resource || depth > MAX_DEPTH || !record.data) {
+    return {
+      ...(record.data ?? {}),
+      incrementalId: record.incrementalId,
+    };
+  }
 
   const fields = resource.fields;
   const data: { [key: string]: any } = {};
@@ -116,7 +121,10 @@ export const getContextDataForRecord = async (
     }
   }
 
-  return data;
+  return {
+    ...data,
+    incrementalId: record.incrementalId,
+  };
 };
 
 /**


### PR DESCRIPTION
# Description

Contextual dashboards backed by a resource record were exposing the record's field data but not its generated incremental ID, so filters like {{context.incrementalId}} never matched anything. This update fixes the shared backend context builder to always include the source record's incrementalId alongside the rest of the context payload. Adds a test as well.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/128988/

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
