### PR TITLE
AB#129134 use-user-context-in-permissions

### DIFF
--- a/__tests__/unit-tests/utils/filter/getFormPermissionFilter.spec.ts
+++ b/__tests__/unit-tests/utils/filter/getFormPermissionFilter.spec.ts
@@ -1,0 +1,163 @@
+import mongoose from 'mongoose';
+import { getFormPermissionFilter } from '@utils/filter/getFormPermissionFilter';
+import { resourcePermission } from '../../../../src/types/permission';
+
+describe('getFormPermissionFilter', () => {
+  const roleId = new mongoose.Types.ObjectId();
+
+  const user = {
+    roles: [{ _id: roleId }],
+    attributes: {
+      region: 'North',
+      locationType: 'Regional Office',
+    },
+  } as any;
+
+  const resource = {
+    id: 'resource-1',
+    fields: [
+      { name: 'region', type: 'text' },
+      { name: 'country', type: 'text' },
+    ],
+    permissions: {
+      [resourcePermission.UPDATE_RECORDS]: [],
+    },
+  } as any;
+
+  it('maps attribute-to-field comparisons to record filters using the current user', () => {
+    resource.permissions[resourcePermission.UPDATE_RECORDS] = [
+      {
+        role: roleId,
+        access: {
+          logic: 'and',
+          filters: [
+            {
+              field: '$attribute.region',
+              operator: 'eq',
+              value: 'region',
+            },
+          ],
+        },
+      },
+    ];
+
+    const filters = getFormPermissionFilter(
+      user,
+      resource,
+      resourcePermission.UPDATE_RECORDS
+    );
+
+    expect(filters).toEqual([
+      {
+        $and: [{ 'data.region': 'North' }],
+      },
+    ]);
+  });
+
+  it('supports literal equality checks on attributes when valueSource is set', () => {
+    resource.permissions[resourcePermission.UPDATE_RECORDS] = [
+      {
+        role: roleId,
+        access: {
+          logic: 'and',
+          filters: [
+            {
+              field: '$attribute.locationType',
+              operator: 'eq',
+              value: 'Regional Office',
+              valueSource: 'literal',
+            },
+            {
+              field: 'country',
+              operator: 'eq',
+              value: 'Tunisia',
+            },
+          ],
+        },
+      },
+    ];
+
+    const filters = getFormPermissionFilter(
+      user,
+      resource,
+      resourcePermission.UPDATE_RECORDS
+    );
+
+    expect(filters).toEqual([
+      {
+        $and: [
+          { _id: { $exists: true } },
+          { 'data.country': { $eq: 'Tunisia' } },
+        ],
+      },
+    ]);
+  });
+
+  it('uses text input operators on attributes without an explicit value source', () => {
+    resource.permissions[resourcePermission.UPDATE_RECORDS] = [
+      {
+        role: roleId,
+        access: {
+          logic: 'and',
+          filters: [
+            {
+              field: '$attribute.locationType',
+              operator: 'contains',
+              value: 'Regional',
+            },
+            {
+              field: 'country',
+              operator: 'eq',
+              value: 'France',
+            },
+          ],
+        },
+      },
+    ];
+
+    const filters = getFormPermissionFilter(
+      user,
+      resource,
+      resourcePermission.UPDATE_RECORDS
+    );
+
+    expect(filters).toEqual([
+      {
+        $and: [
+          { _id: { $exists: true } },
+          { 'data.country': { $eq: 'France' } },
+        ],
+      },
+    ]);
+  });
+
+  it('turns unmatched literal attribute checks into an impossible filter', () => {
+    resource.permissions[resourcePermission.UPDATE_RECORDS] = [
+      {
+        role: roleId,
+        access: {
+          logic: 'and',
+          filters: [
+            {
+              field: '$attribute.locationType',
+              operator: 'contains',
+              value: 'Head Office',
+            },
+          ],
+        },
+      },
+    ];
+
+    const filters = getFormPermissionFilter(
+      user,
+      resource,
+      resourcePermission.UPDATE_RECORDS
+    );
+
+    expect(filters).toEqual([
+      {
+        $and: [{ _id: { $exists: false } }],
+      },
+    ]);
+  });
+});

--- a/src/utils/filter/getFormPermissionFilter.ts
+++ b/src/utils/filter/getFormPermissionFilter.ts
@@ -26,6 +26,7 @@ export const getFormPermissionFilter = (
           filter,
           x.access &&
             getFilter(x.access, object.fields, {
+              user,
               resourceFieldsById: {
                 [object instanceof Form ? object.resource : object.id]:
                   object.fields,

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -252,13 +252,16 @@ const buildMongoFilter = (
       }
 
       const isAttributeFilter = filter.field.startsWith('$attribute.');
+      if (isAttributeFilter && !context?.user) {
+        return ATTRIBUTE_MATCH_NONE_FILTER;
+      }
       const attributeValueSource =
         filter.valueSource === 'literal' ||
         !ATTRIBUTE_FIELD_OPERATORS.includes(filter.operator)
           ? 'literal'
           : 'field';
       const attrValue = isAttributeFilter
-        ? context.user?.attributes?.[filter.field.split('.')[1]]
+        ? context.user.attributes?.[filter.field.split('.')[1]]
         : '';
       if (isAttributeFilter && attributeValueSource === 'literal') {
         return buildLiteralAttributeFilter(

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -62,6 +62,113 @@ export const extractFilterFields = (filter: any): string[] => {
   return fields;
 };
 
+/** Mongo predicate that matches every record. */
+const ATTRIBUTE_MATCH_ALL_FILTER = { _id: { $exists: true } };
+
+/** Mongo predicate that matches no record. */
+const ATTRIBUTE_MATCH_NONE_FILTER = { _id: { $exists: false } };
+
+/** Operators that compare an attribute against another field value. */
+const ATTRIBUTE_FIELD_OPERATORS = ['eq', 'neq', 'in', 'notin'];
+
+/**
+ * Returns a Mongo filter that either always matches or never matches.
+ *
+ * @param matches whether the condition should match
+ * @returns Mongo filter
+ */
+const buildStaticAttributeFilter = (matches: boolean) =>
+  matches ? ATTRIBUTE_MATCH_ALL_FILTER : ATTRIBUTE_MATCH_NONE_FILTER;
+
+/**
+ * Converts any attribute value to a comparable string.
+ *
+ * @param value value to normalize
+ * @returns normalized string
+ */
+const normalizeAttributeValue = (value: any): string => String(value ?? '');
+
+/**
+ * Evaluates a user-attribute comparison that does not depend on record data.
+ *
+ * @param operator filter operator
+ * @param attributeValue current user's attribute value
+ * @param compareValue configured literal value
+ * @returns Mongo filter that either matches all or no records
+ */
+const buildLiteralAttributeFilter = (
+  operator: string,
+  attributeValue: any,
+  compareValue: any
+) => {
+  const attributeText = normalizeAttributeValue(attributeValue);
+  const compareText = normalizeAttributeValue(compareValue);
+  const attributeTextLower = attributeText.toLowerCase();
+  const compareTextLower = compareText.toLowerCase();
+  const compareValues = (
+    Array.isArray(compareValue)
+      ? compareValue
+      : compareText
+          .split(',')
+          .map((value) => value.trim())
+          .filter((value) => value !== '')
+  ).map((value) => normalizeAttributeValue(value));
+
+  switch (operator) {
+    case filterOperator.EQUAL_TO: {
+      return buildStaticAttributeFilter(attributeText === compareText);
+    }
+    case filterOperator.NOT_EQUAL_TO: {
+      return buildStaticAttributeFilter(attributeText !== compareText);
+    }
+    case filterOperator.CONTAINS: {
+      return buildStaticAttributeFilter(
+        attributeTextLower.includes(compareTextLower)
+      );
+    }
+    case filterOperator.DOES_NOT_CONTAIN: {
+      return buildStaticAttributeFilter(
+        !attributeTextLower.includes(compareTextLower)
+      );
+    }
+    case filterOperator.STARTS_WITH: {
+      return buildStaticAttributeFilter(
+        attributeTextLower.startsWith(compareTextLower)
+      );
+    }
+    case filterOperator.ENDS_WITH: {
+      return buildStaticAttributeFilter(
+        attributeTextLower.endsWith(compareTextLower)
+      );
+    }
+    case filterOperator.IN: {
+      return buildStaticAttributeFilter(compareValues.includes(attributeText));
+    }
+    case filterOperator.NOT_IN: {
+      return buildStaticAttributeFilter(!compareValues.includes(attributeText));
+    }
+    case filterOperator.IS_NULL: {
+      return buildStaticAttributeFilter(
+        attributeValue === null || attributeValue === undefined
+      );
+    }
+    case filterOperator.IS_NOT_NULL: {
+      return buildStaticAttributeFilter(
+        attributeValue !== null && attributeValue !== undefined
+      );
+    }
+    case filterOperator.IS_EMPTY: {
+      return buildStaticAttributeFilter(attributeText === '');
+    }
+    case filterOperator.IS_NOT_EMPTY: {
+      return buildStaticAttributeFilter(attributeText !== '');
+    }
+    default: {
+      return ATTRIBUTE_MATCH_NONE_FILTER;
+    }
+  }
+};
+
 /**
  * Transforms query filter into mongo filter.
  *
@@ -145,9 +252,21 @@ const buildMongoFilter = (
       }
 
       const isAttributeFilter = filter.field.startsWith('$attribute.');
+      const attributeValueSource =
+        filter.valueSource === 'literal' ||
+        !ATTRIBUTE_FIELD_OPERATORS.includes(filter.operator)
+          ? 'literal'
+          : 'field';
       const attrValue = isAttributeFilter
-        ? context.user.attributes?.[filter.field.split('.')[1]]
+        ? context.user?.attributes?.[filter.field.split('.')[1]]
         : '';
+      if (isAttributeFilter && attributeValueSource === 'literal') {
+        return buildLiteralAttributeFilter(
+          filter.operator,
+          attrValue,
+          filter.value
+        );
+      }
       if (isAttributeFilter)
         fieldName = FLAT_DEFAULT_FIELDS.includes(filter.value)
           ? filter.value

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -69,7 +69,12 @@ const ATTRIBUTE_MATCH_ALL_FILTER = { _id: { $exists: true } };
 const ATTRIBUTE_MATCH_NONE_FILTER = { _id: { $exists: false } };
 
 /** Operators that compare an attribute against another field value. */
-const ATTRIBUTE_FIELD_OPERATORS = ['eq', 'neq', 'in', 'notin'];
+const ATTRIBUTE_FIELD_OPERATORS = [
+  filterOperator.EQUAL_TO,
+  filterOperator.NOT_EQUAL_TO,
+  filterOperator.IN,
+  filterOperator.NOT_IN,
+];
 
 /**
  * Returns a Mongo filter that either always matches or never matches.


### PR DESCRIPTION
# Description

This PR adds support for literal values in role resource access filters.

For attribute filters, eq and neq can now compare either to another field or to a typed value. Text operators like contains, starts with, and ends with also work with attribute filters. On the backend, permission filters now correctly handle these literal attribute comparisons using the current user’s attributes.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Ran frontend checks with eslint and tsc --noEmit, and ran the backend unit test __tests__/unit-tests/utils/filter/getFormPermissionFilter.spec.ts.

- verified manually in Back Office -> Settings -> Roles -> Resources that attribute filters can switch between Field and Value, save correctly, and enforce access as expected.

## Screenshots


<img width="1018" height="209" alt="image" src="https://github.com/user-attachments/assets/0a01f423-addc-4d6d-b48c-47ad7246c130" />
<img width="968" height="350" alt="image" src="https://github.com/user-attachments/assets/e6b0651d-6c97-436c-8514-dc7ceddcaefc" />
<img width="390" height="324" alt="image" src="https://github.com/user-attachments/assets/6cd11c8c-4876-4eed-93ab-a1e538791470" />


# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [x] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
