### PR TITLE
AB#129193 - Add more options to calculate fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# [2.16.0](https://github.com/ReliefApplications/ems-backend/compare/v2.15.0...v2.16.0) (2026-04-13)
+
+
+### Bug Fixes
+
+* Editing record with fields not defined in resource could fail ([#1217](https://github.com/ReliefApplications/ems-backend/issues/1217)) ([480929c](https://github.com/ReliefApplications/ems-backend/commit/480929c030a6d964d646ba85ad60343d7b7ea62d)), closes [AB#125221](https://github.com/AB/issues/125221)
+
+
+### Features
+
+* add clone record action in dashboards ([#1208](https://github.com/ReliefApplications/ems-backend/issues/1208)) ([43559db](https://github.com/ReliefApplications/ems-backend/commit/43559db1e671c1ff4fbcad7439120327d99adf13)), closes [AB#118658](https://github.com/AB/issues/118658)
+* Admins can configure auto redirection after cloning from dashboard ([#1212](https://github.com/ReliefApplications/ems-backend/issues/1212)) ([9de1a8c](https://github.com/ReliefApplications/ems-backend/commit/9de1a8c142f1dbf7610e9168a838b0fc86bdba34)), closes [AB#118658](https://github.com/AB/issues/118658)
+* Display only resources question ([#1214](https://github.com/ReliefApplications/ems-backend/issues/1214)) ([b9402aa](https://github.com/ReliefApplications/ems-backend/commit/b9402aab0f93b2193bfbb4376bd1c55bb3013776)), closes [AB#122462](https://github.com/AB/issues/122462)
+* Enable menu and account on one line, and icon-only menu items ([#1213](https://github.com/ReliefApplications/ems-backend/issues/1213)) ([30345c4](https://github.com/ReliefApplications/ems-backend/commit/30345c477e0819a19c1182fa10030d89cb7ad32c)), closes [AB#121668](https://github.com/AB/issues/121668)
+* People picker in forms  ([#1216](https://github.com/ReliefApplications/ems-backend/issues/1216)) ([544b5ab](https://github.com/ReliefApplications/ems-backend/commit/544b5ab0fd4c7113b7c5ac36e7fa8b16c908f909)), closes [AB#68534](https://github.com/AB/issues/68534)
+
 # [2.15.0](https://github.com/ReliefApplications/ems-backend/compare/v2.14.0...v2.15.0) (2025-09-05)
 
 

--- a/__tests__/unit-tests/utils/aggregation/buildCalculatedFieldPipeline.spec.ts
+++ b/__tests__/unit-tests/utils/aggregation/buildCalculatedFieldPipeline.spec.ts
@@ -1,0 +1,254 @@
+import { ReferenceData } from '@models';
+import buildCalculatedFieldPipeline from '@utils/aggregation/buildCalculatedFieldPipeline';
+import * as displayTextUtils from '@utils/form/getDisplayText';
+import { getExpressionFromString } from '@utils/aggregation/expressionFromString';
+
+describe('buildCalculatedFieldPipeline', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should parse field text modifiers as dedicated field operators', () => {
+    const expression = getExpressionFromString(
+      '{{calc.eq({{data.country:text}}; "France")}}'
+    );
+
+    expect(expression).toMatchObject({
+      operation: 'eq',
+      operator1: {
+        type: 'field',
+        value: {
+          field: 'country',
+          display: 'text',
+        },
+      },
+      operator2: {
+        type: 'const',
+        value: 'France',
+      },
+    });
+  });
+
+  it('should preserve array shape when resolving multiselect display text', async () => {
+    const pipeline = await buildCalculatedFieldPipeline(
+      '{{calc.includes({{data.tags:text}}; "Alpha")}}',
+      'hasAlpha',
+      'UTC',
+      {
+        fields: [
+          {
+            name: 'tags',
+            type: 'tagbox',
+            choices: [
+              { value: 'alpha', text: 'Alpha' },
+              { value: 'beta', text: 'Beta' },
+            ],
+          },
+        ],
+      }
+    );
+
+    expect(pipeline[0]).toEqual({
+      $addFields: {
+        'aux.displayText.tags': {
+          $cond: {
+            if: { $isArray: '$data.tags' },
+            then: {
+              $map: {
+                input: '$data.tags',
+                as: 'selectedValue',
+                in: {
+                  $let: {
+                    vars: {
+                      choiceValues: ['alpha', 'beta'],
+                      choiceTexts: ['Alpha', 'Beta'],
+                      normalizedSelectedValue: {
+                        $ifNull: ['$$selectedValue.value', '$$selectedValue'],
+                      },
+                    },
+                    in: {
+                      $let: {
+                        vars: {
+                          choiceIndex: {
+                            $indexOfArray: [
+                              '$$choiceValues',
+                              '$$normalizedSelectedValue',
+                            ],
+                          },
+                        },
+                        in: {
+                          $cond: {
+                            if: { $eq: ['$$choiceIndex', -1] },
+                            then: '$$normalizedSelectedValue',
+                            else: {
+                              $arrayElemAt: ['$$choiceTexts', '$$choiceIndex'],
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            else: {
+              $ifNull: ['$data.tags.value', '$data.tags'],
+            },
+          },
+        },
+      },
+    });
+    expect(pipeline[1]).toEqual({
+      $addFields: {
+        'data.hasAlpha': {
+          $cond: {
+            if: { $isArray: '$aux.displayText.tags' },
+            then: {
+              $in: ['Alpha', '$aux.displayText.tags'],
+            },
+            else: false,
+          },
+        },
+      },
+    });
+  });
+
+  it('should support static strings and info values in concat expressions', async () => {
+    const pipeline = await buildCalculatedFieldPipeline(
+      '{{calc.concat({{data.country:text}}; " - "; {{info.incrementalId}})}}',
+      'label',
+      'UTC',
+      {
+        fields: [
+          {
+            name: 'country',
+            type: 'dropdown',
+            choices: [{ value: 'fr', text: 'France' }],
+          },
+        ],
+      }
+    );
+
+    const concatStep = pipeline[1].$addFields['data.label'];
+
+    expect(concatStep.$concat[0]).toHaveProperty('$cond');
+    expect(concatStep.$concat[1]).toEqual({
+      $convert: {
+        input: ' - ',
+        to: 'string',
+        onError: '',
+        onNull: '',
+      },
+    });
+    expect(concatStep.$concat[2]).toHaveProperty('$cond');
+  });
+
+  it('should normalize wrapped reference-data values before matching labels', async () => {
+    jest.spyOn(displayTextUtils, 'getFullChoices').mockResolvedValue([
+      { value: 'fr', text: 'France' },
+      { value: 'de', text: 'Germany' },
+    ]);
+    jest.spyOn(ReferenceData, 'findById').mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue({
+          valueField: 'id',
+        }),
+      }),
+    } as any);
+
+    const pipeline = await buildCalculatedFieldPipeline(
+      '{{calc.eq({{data.country:text}}; "France")}}',
+      'matches',
+      'UTC',
+      {
+        fields: [
+          {
+            name: 'country',
+            type: 'dropdown',
+            referenceData: {
+              id: '67f6f3e2b5b8d2c2f3d1a123',
+            },
+          },
+        ],
+      }
+    );
+
+    expect(
+      pipeline[0].$addFields['aux.displayText.country'].$let.vars
+        .normalizedValue
+    ).toEqual({
+      $ifNull: [
+        '$data.country.value.id',
+        {
+          $ifNull: [
+            '$data.country.id',
+            {
+              $ifNull: ['$data.country.value', '$data.country'],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('should support direct field-text expressions without a calc wrapper', async () => {
+    const pipeline = await buildCalculatedFieldPipeline(
+      '{{data.status:text}}',
+      'status_check',
+      'UTC',
+      {
+        fields: [
+          {
+            name: 'status',
+            type: 'dropdown',
+            choices: [
+              { value: 'open', text: 'Open' },
+              { value: 'closed', text: 'Closed' },
+            ],
+          },
+        ],
+      }
+    );
+
+    expect(pipeline).toEqual([
+      {
+        $addFields: {
+          'aux.displayText.status': {
+            $let: {
+              vars: {
+                choiceValues: ['open', 'closed'],
+                choiceTexts: ['Open', 'Closed'],
+                normalizedValue: {
+                  $ifNull: ['$data.status.value', '$data.status'],
+                },
+              },
+              in: {
+                $let: {
+                  vars: {
+                    choiceIndex: {
+                      $indexOfArray: ['$$choiceValues', '$$normalizedValue'],
+                    },
+                  },
+                  in: {
+                    $cond: {
+                      if: { $eq: ['$$choiceIndex', -1] },
+                      then: '$$normalizedValue',
+                      else: {
+                        $arrayElemAt: ['$$choiceTexts', '$$choiceIndex'],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        $addFields: {
+          'data.status_check': '$aux.displayText.status',
+        },
+      },
+    ]);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ems-backend",
-  "version": "2.16.0-rc.6",
+  "version": "2.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ems-backend",
-      "version": "2.16.0-rc.6",
+      "version": "2.16.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ems-backend",
-  "version": "2.16.0-rc.6",
+  "version": "2.16.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/const/calculatedFields.ts
+++ b/src/const/calculatedFields.ts
@@ -1,11 +1,28 @@
-/**
- * Interface for a simple operator
- * If type is 'value', the operator is a constant, stored in the value field
- * If type is 'field', the operator is the value for that the field with the name stored in value
- */
-interface SimpleOperator {
-  type: 'const' | 'field' | 'info';
+/** Supported display modifiers for field operators */
+export type FieldDisplayMode = 'text';
+
+/** Typed value for field operators */
+export interface FieldOperatorValue {
+  field: string;
+  display?: FieldDisplayMode;
+}
+
+/** Interface for constant operators */
+interface ConstOperator {
+  type: 'const';
   value: string | number | boolean;
+}
+
+/** Interface for field operators */
+interface FieldOperator {
+  type: 'field';
+  value: FieldOperatorValue;
+}
+
+/** Interface for info operators */
+interface InfoOperator {
+  type: 'info';
+  value: string;
 }
 
 /**
@@ -16,7 +33,11 @@ interface RecursiveOperator {
   value: Operation;
 }
 
-export type Operator = SimpleOperator | RecursiveOperator;
+export type Operator =
+  | ConstOperator
+  | FieldOperator
+  | InfoOperator
+  | RecursiveOperator;
 
 export type OperationTypes =
   | SingleOperatorOperationsTypes

--- a/src/schema/query/recordsAggregation.query.ts
+++ b/src/schema/query/recordsAggregation.query.ts
@@ -358,11 +358,15 @@ export default {
           // If field is a calculated field
           if (field && field.isCalculated) {
             pipeline.unshift(
-              ...buildCalculatedFieldPipeline(
+              ...(await buildCalculatedFieldPipeline(
                 field.expression,
                 field.name,
-                context.timeZone
-              )
+                context.timeZone,
+                {
+                  fields: resource.fields,
+                  context,
+                }
+              ))
             );
           }
 

--- a/src/schema/types/form.type.ts
+++ b/src/schema/types/form.type.ts
@@ -7,6 +7,7 @@ import {
   GraphQLInt,
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
+import mongoose from 'mongoose';
 import {
   AccessType,
   ResourceType,
@@ -27,6 +28,7 @@ import extendAbilityForRecords from '@security/extendAbilityForRecords';
 import extendAbilityForContent from '@security/extendAbilityForContent';
 import { getMetaData } from '@utils/form/metadata.helper';
 import { getAccessibleFields } from '@utils/form';
+import buildCalculatedFieldPipeline from '@utils/aggregation/buildCalculatedFieldPipeline';
 import { accessibleBy } from '@casl/mongoose';
 
 /** Default page size */
@@ -81,8 +83,9 @@ export const FormType = new GraphQLObjectType({
         archived: { type: GraphQLBoolean },
       },
       async resolve(parent, args, context) {
+        const first = args.first || DEFAULT_FIRST;
         let mongooseFilter: any = {
-          form: parent.id,
+          form: new mongoose.Types.ObjectId(String(parent.id)),
         };
         if (args.archived) {
           Object.assign(mongooseFilter, { archived: true });
@@ -104,7 +107,9 @@ export const FormType = new GraphQLObjectType({
         const cursorFilters = args.afterCursor
           ? {
               _id: {
-                $gt: decodeCursor(args.afterCursor),
+                $gt: new mongoose.Types.ObjectId(
+                  String(decodeCursor(args.afterCursor))
+                ),
               },
             }
           : {};
@@ -114,21 +119,55 @@ export const FormType = new GraphQLObjectType({
         const permissionFilters = Record.find(
           accessibleBy(ability, 'read').Record
         ).getFilter();
+        const calculatedFieldsAggregation: any[] = [];
+        for (const field of (parent.fields || []).filter(
+          (candidate: any) => candidate.isCalculated
+        )) {
+          calculatedFieldsAggregation.push(
+            ...(await buildCalculatedFieldPipeline(
+              field.expression,
+              field.name,
+              context.timeZone,
+              {
+                fields: parent.fields,
+                context,
+              }
+            ))
+          );
+        }
         // Get data
-        let items = await Record.find({
-          $and: [cursorFilters, mongooseFilter, permissionFilters],
-        }).limit(args.first + 1);
-        const hasNextPage = items.length > args.first;
+        let items = await Record.aggregate([
+          {
+            $match: {
+              $and: [cursorFilters, mongooseFilter, permissionFilters],
+            },
+          },
+          ...calculatedFieldsAggregation,
+          {
+            $sort: {
+              _id: 1,
+            },
+          },
+          {
+            $limit: first + 1,
+          },
+        ]);
+        const hasNextPage = items.length > first;
         if (hasNextPage) {
           items = items.slice(0, items.length - 1);
         }
-        const edges = items.map((r) => ({
-          cursor: encodeCursor(r.id.toString()),
-          node: Object.assign(
-            getAccessibleFields(r, ability).toObject({ minimize: false }),
-            { id: r._id }
-          ),
-        }));
+        const edges = items.map((r) => {
+          const accessibleRecord = getAccessibleFields(r, ability) as any;
+          const node =
+            typeof accessibleRecord.toObject === 'function'
+              ? accessibleRecord.toObject({ minimize: false })
+              : accessibleRecord;
+
+          return {
+            cursor: encodeCursor(r._id.toString()),
+            node: Object.assign(node, { id: r._id }),
+          };
+        });
         return {
           pageInfo: {
             hasNextPage,

--- a/src/schema/types/resource.type.ts
+++ b/src/schema/types/resource.type.ts
@@ -6,6 +6,7 @@ import extendAbilityForRecords, {
 } from '@security/extendAbilityForRecords';
 import { getAccessibleFields } from '@utils/form';
 import { getMetaData } from '@utils/form/metadata.helper';
+import buildCalculatedFieldPipeline from '@utils/aggregation/buildCalculatedFieldPipeline';
 import getFilter from '@utils/schema/resolvers/Query/getFilter';
 import {
   GraphQLBoolean,
@@ -17,6 +18,7 @@ import {
   GraphQLString,
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
+import mongoose from 'mongoose';
 import { pluralize } from 'inflection';
 import { get, indexOf } from 'lodash';
 import {
@@ -177,8 +179,9 @@ export const ResourceType = new GraphQLObjectType({
         archived: { type: GraphQLBoolean },
       },
       async resolve(parent, args, context) {
+        const first = args.first || DEFAULT_FIRST;
         let mongooseFilter: any = {
-          resource: parent.id,
+          resource: new mongoose.Types.ObjectId(String(parent.id)),
         };
         if (args.archived) {
           Object.assign(mongooseFilter, { archived: true });
@@ -200,7 +203,9 @@ export const ResourceType = new GraphQLObjectType({
         const cursorFilters = args.afterCursor
           ? {
               _id: {
-                $gt: decodeCursor(args.afterCursor),
+                $gt: new mongoose.Types.ObjectId(
+                  String(decodeCursor(args.afterCursor))
+                ),
               },
             }
           : {};
@@ -210,20 +215,55 @@ export const ResourceType = new GraphQLObjectType({
         const permissionFilters = Record.find(
           accessibleBy(ability, 'read').Record
         ).getFilter();
-        let items = await Record.find({
-          $and: [cursorFilters, mongooseFilter, permissionFilters],
-        }).limit(args.first + 1);
-        const hasNextPage = items.length > args.first;
+        const calculatedFieldsAggregation: any[] = [];
+        for (const field of (parent.fields || []).filter(
+          (candidate: any) => candidate.isCalculated
+        )) {
+          calculatedFieldsAggregation.push(
+            ...(await buildCalculatedFieldPipeline(
+              field.expression,
+              field.name,
+              context.timeZone,
+              {
+                fields: parent.fields,
+                context,
+              }
+            ))
+          );
+        }
+
+        let items = await Record.aggregate([
+          {
+            $match: {
+              $and: [cursorFilters, mongooseFilter, permissionFilters],
+            },
+          },
+          ...calculatedFieldsAggregation,
+          {
+            $sort: {
+              _id: 1,
+            },
+          },
+          {
+            $limit: first + 1,
+          },
+        ]);
+        const hasNextPage = items.length > first;
         if (hasNextPage) {
           items = items.slice(0, items.length - 1);
         }
-        const edges = items.map((r) => ({
-          cursor: encodeCursor(r.id.toString()),
-          node: Object.assign(
-            getAccessibleFields(r, ability).toObject({ minimize: false }),
-            { id: r._id }
-          ),
-        }));
+        const edges = items.map((r) => {
+          const accessibleRecord = getAccessibleFields(r, ability) as any;
+          const node =
+            typeof accessibleRecord.toObject === 'function'
+              ? accessibleRecord.toObject({ minimize: false })
+              : accessibleRecord;
+
+          return {
+            cursor: encodeCursor(r._id.toString()),
+            node: Object.assign(node, { id: r._id }),
+          };
+        });
         return {
           pageInfo: {
             hasNextPage,

--- a/src/utils/aggregation/buildCalculatedFieldPipeline.ts
+++ b/src/utils/aggregation/buildCalculatedFieldPipeline.ts
@@ -1,4 +1,8 @@
-import { flattenDeep, isNil } from 'lodash';
+import { MULTISELECT_TYPES } from '@const/fieldTypes';
+import { ReferenceData } from '@models';
+import { getFullChoices } from '@utils/form/getDisplayText';
+import { flattenDeep } from 'lodash';
+import { PipelineStage } from 'mongoose';
 import {
   DateOperationTypes,
   DoubleOperatorOperationsTypes,
@@ -7,12 +11,27 @@ import {
   Operator,
   SingleOperatorOperationsTypes,
 } from '../../const/calculatedFields';
-import { getExpressionFromString } from './expressionFromString';
-import { PipelineStage } from 'mongoose';
+import {
+  getExpressionFromString,
+  getOperatorFromString,
+} from './expressionFromString';
 
 type Dependency = {
   operation: Operation;
   path: string;
+};
+
+type FieldTextPaths = Record<string, string>;
+
+type BuildCalculatedFieldPipelineOptions = {
+  fields?: any[];
+  context?: any;
+};
+
+type DisplayTextStage = {
+  fieldPath: string;
+  targetPath: string;
+  step: PipelineStage.AddFields;
 };
 
 /** Special date operators enum */
@@ -56,44 +75,500 @@ const operationMap: {
 };
 
 /**
- * If provided a simple operator, returns the value, otherwise returns null
+ * Checks whether an operator is an expression.
+ *
+ * @param operator Operator to check
+ * @returns Whether the operator is an expression
+ */
+const isExpressionOperator = (
+  operator: Operator | null
+): operator is Extract<Operator, { type: 'expression' }> =>
+  Boolean(operator && operator.type === 'expression');
+
+/**
+ * If provided a simple operator, returns the value, otherwise returns null.
  *
  * @param operator The operator to get value from
+ * @param fieldTextPaths Pre-computed paths for `:text` field references
  * @returns The value of the operator, or null if it is not a simple operator
  */
-const getSimpleOperatorValue = (operator: Operator) => {
+const getSimpleOperatorValue = (
+  operator: Operator | null,
+  fieldTextPaths: FieldTextPaths = {}
+) => {
+  if (!operator) return null;
+
   if (operator.type === 'const') return operator.value;
-  if (operator.type === 'field') return `$data.${operator.value}`;
+
+  if (operator.type === 'field') {
+    const fieldPath = operator.value.field;
+
+    if (operator.value.display === 'text' && fieldTextPaths[fieldPath]) {
+      return `$${fieldTextPaths[fieldPath]}`;
+    }
+
+    return `$data.${fieldPath}`;
+  }
+
   if (operator.type === 'info') {
     if (operator.value === infoOperators.CREATED_AT) return '$createdAt';
     if (operator.value === infoOperators.UPDATED_AT) return '$modifiedAt';
     if (operator.value === infoOperators.ID) return '$incrementalId';
   }
+
   return null;
 };
 
 /**
- * Creates the pipeline stage for a 'today' operation
+ * Collects all field paths referenced with the `:text` modifier in an operation.
+ *
+ * @param operation Operation to inspect
+ * @param displayFields Mutable set of discovered field paths
+ * @returns Discovered field paths
+ */
+const collectDisplayTextFieldPaths = (
+  operation: Operation,
+  displayFields = new Set<string>()
+) => {
+  const collectOperator = (operator: Operator | null) => {
+    if (!operator) return;
+
+    if (operator.type === 'field' && operator.value.display === 'text') {
+      displayFields.add(operator.value.field);
+      return;
+    }
+
+    if (isExpressionOperator(operator)) {
+      collectDisplayTextFieldPaths(operator.value, displayFields);
+    }
+  };
+
+  switch (operation.operation) {
+    case 'today': {
+      collectOperator(operation.operator);
+      break;
+    }
+    case 'year':
+    case 'month':
+    case 'day':
+    case 'hour':
+    case 'minute':
+    case 'second':
+    case 'millisecond':
+    case 'date':
+    case 'exists':
+    case 'size':
+    case 'toInt':
+    case 'toLong': {
+      collectOperator(operation.operator);
+      break;
+    }
+    case 'sub':
+    case 'div':
+    case 'gte':
+    case 'gt':
+    case 'lte':
+    case 'lt':
+    case 'eq':
+    case 'ne':
+    case 'datediff':
+    case 'includes': {
+      collectOperator(operation.operator1);
+      collectOperator(operation.operator2);
+      break;
+    }
+    case 'add':
+    case 'mul':
+    case 'and':
+    case 'or':
+    case 'if':
+    case 'substr':
+    case 'concat': {
+      operation.operators.forEach((operator) => collectOperator(operator));
+      break;
+    }
+  }
+
+  return displayFields;
+};
+
+/**
+ * Collects `:text` field references from a root operator.
+ *
+ * @param operator Root operator
+ * @param displayFields Mutable set of discovered field paths
+ * @returns Discovered field paths
+ */
+const collectDisplayTextFieldPathsFromOperator = (
+  operator: Operator,
+  displayFields = new Set<string>()
+) => {
+  if (operator.type === 'field' && operator.value.display === 'text') {
+    displayFields.add(operator.value.field);
+    return displayFields;
+  }
+
+  if (isExpressionOperator(operator)) {
+    return collectDisplayTextFieldPaths(operator.value, displayFields);
+  }
+
+  return displayFields;
+};
+
+/**
+ * Gets a field definition from the available fields list.
+ *
+ * @param fieldPath Field path referenced in the expression
+ * @param fields Available fields
+ * @returns Matching field definition, if any
+ */
+const getFieldDefinition = (fieldPath: string, fields: any[]) => {
+  const [fieldName] = fieldPath.split('.');
+  return fields.find((field) => field?.name === fieldName);
+};
+
+/**
+ * Extracts the comparable value from a choice item.
+ *
+ * @param choice Choice definition
+ * @returns Choice value
+ */
+const getChoiceValue = (choice: any) =>
+  typeof choice === 'object' && choice !== null && 'value' in choice
+    ? choice.value
+    : choice;
+
+/**
+ * Extracts the text value from a choice item.
+ *
+ * @param choice Choice definition
+ * @returns Choice text
+ */
+const getChoiceText = (choice: any) =>
+  typeof choice === 'object' && choice !== null && 'text' in choice
+    ? choice.text
+    : choice;
+
+/**
+ * Resolves the field used to compare a stored non-primitive value with its
+ * corresponding choice value.
+ *
+ * @param field Field definition
+ * @returns Comparable field name, when applicable
+ */
+const getComparableValueField = async (field: any): Promise<string | null> => {
+  if (!field?.referenceData?.id) {
+    return null;
+  }
+
+  try {
+    const referenceData = await ReferenceData.findById(field.referenceData.id)
+      .select('valueField')
+      .lean();
+
+    return referenceData?.valueField || null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Builds a Mongo expression that extracts the primitive comparable value from a
+ * stored select/tagbox value.
+ *
+ * @param sourcePath Source value path
+ * @param comparableField Optional reference-data comparable field
+ * @returns Mongo expression resolving the comparable value
+ */
+const buildComparableValueExpression = (
+  sourcePath: string,
+  comparableField?: string | null
+) => {
+  const wrappedValuePath = `${sourcePath}.value`;
+
+  if (!comparableField) {
+    return {
+      $ifNull: [wrappedValuePath, sourcePath],
+    };
+  }
+
+  return {
+    $ifNull: [
+      `${wrappedValuePath}.${comparableField}`,
+      {
+        $ifNull: [
+          `${sourcePath}.${comparableField}`,
+          {
+            $ifNull: [wrappedValuePath, sourcePath],
+          },
+        ],
+      },
+    ],
+  };
+};
+
+/**
+ * Builds an auxiliary stage that resolves the display text for a field.
+ *
+ * @param fieldPath Expression field path
+ * @param fields Available fields
+ * @param context Request context
+ * @returns Display text stage information
+ */
+const buildDisplayTextStage = async (
+  fieldPath: string,
+  fields: any[],
+  context: any
+): Promise<DisplayTextStage | null> => {
+  const field = getFieldDefinition(fieldPath, fields);
+  if (
+    !field ||
+    !(
+      field.choices ||
+      field.choicesByUrl ||
+      field.choicesByGraphQL ||
+      field.referenceData
+    )
+  ) {
+    return null;
+  }
+
+  const choices = (await getFullChoices(field, context)) || [];
+  if (!choices.length) {
+    return null;
+  }
+
+  const comparableField = await getComparableValueField(field);
+  const choiceValues = choices.map((choice) => getChoiceValue(choice));
+  const choiceTexts = choices.map((choice) => getChoiceText(choice));
+  const targetPath = `aux.displayText.${fieldPath}`;
+  const sourcePath = `$data.${fieldPath}`;
+  const normalizedSourceValue = buildComparableValueExpression(
+    sourcePath,
+    comparableField
+  );
+
+  if (MULTISELECT_TYPES.includes(field.type)) {
+    return {
+      fieldPath,
+      targetPath,
+      step: {
+        $addFields: {
+          [targetPath]: {
+            $cond: {
+              if: { $isArray: sourcePath },
+              then: {
+                $map: {
+                  input: sourcePath,
+                  as: 'selectedValue',
+                  in: {
+                    $let: {
+                      vars: {
+                        choiceValues,
+                        choiceTexts,
+                        normalizedSelectedValue: buildComparableValueExpression(
+                          '$$selectedValue',
+                          comparableField
+                        ),
+                      },
+                      in: {
+                        $let: {
+                          vars: {
+                            choiceIndex: {
+                              $indexOfArray: [
+                                '$$choiceValues',
+                                '$$normalizedSelectedValue',
+                              ],
+                            },
+                          },
+                          in: {
+                            $cond: {
+                              if: { $eq: ['$$choiceIndex', -1] },
+                              then: '$$normalizedSelectedValue',
+                              else: {
+                                $arrayElemAt: [
+                                  '$$choiceTexts',
+                                  '$$choiceIndex',
+                                ],
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+              else: normalizedSourceValue,
+            },
+          },
+        },
+      },
+    };
+  }
+
+  return {
+    fieldPath,
+    targetPath,
+    step: {
+      $addFields: {
+        [targetPath]: {
+          $let: {
+            vars: {
+              choiceValues,
+              choiceTexts,
+              normalizedValue: normalizedSourceValue,
+            },
+            in: {
+              $let: {
+                vars: {
+                  choiceIndex: {
+                    $indexOfArray: ['$$choiceValues', '$$normalizedValue'],
+                  },
+                },
+                in: {
+                  $cond: {
+                    if: { $eq: ['$$choiceIndex', -1] },
+                    then: '$$normalizedValue',
+                    else: {
+                      $arrayElemAt: ['$$choiceTexts', '$$choiceIndex'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+};
+
+/**
+ * Builds all auxiliary stages required for `:text` field references.
+ *
+ * @param operation Parsed calculated-field operation
+ * @param fields Available fields
+ * @param context Request context
+ * @returns Auxiliary stages and their corresponding field-path mapping
+ */
+const buildDisplayTextStages = async (
+  operation: Operation,
+  fields: any[] = [],
+  context?: any
+) => {
+  const displayFieldPaths = Array.from(collectDisplayTextFieldPaths(operation));
+
+  if (displayFieldPaths.length === 0 || fields.length === 0) {
+    return {
+      stages: [] as PipelineStage.AddFields[],
+      fieldTextPaths: {} as FieldTextPaths,
+    };
+  }
+
+  const mappings = await Promise.all(
+    displayFieldPaths.map((fieldPath) =>
+      buildDisplayTextStage(fieldPath, fields, context)
+    )
+  );
+
+  return mappings.reduce(
+    (acc, mapping) => {
+      if (!mapping) {
+        return acc;
+      }
+
+      acc.stages.push(mapping.step);
+      acc.fieldTextPaths[mapping.fieldPath] = mapping.targetPath;
+      return acc;
+    },
+    {
+      stages: [] as PipelineStage.AddFields[],
+      fieldTextPaths: {} as FieldTextPaths,
+    }
+  );
+};
+
+/**
+ * Builds auxiliary stages required for `:text` references found on a root
+ * operator, including direct `{{data.field:text}}` expressions.
+ *
+ * @param operator Root parsed operator
+ * @param fields Available fields
+ * @param context Request context
+ * @returns Auxiliary stages and their corresponding field-path mapping
+ */
+const buildDisplayTextStagesFromOperator = async (
+  operator: Operator,
+  fields: any[] = [],
+  context?: any
+) => {
+  if (isExpressionOperator(operator)) {
+    return buildDisplayTextStages(operator.value, fields, context);
+  }
+
+  const displayFieldPaths = Array.from(
+    collectDisplayTextFieldPathsFromOperator(operator)
+  );
+
+  if (displayFieldPaths.length === 0 || fields.length === 0) {
+    return {
+      stages: [] as PipelineStage.AddFields[],
+      fieldTextPaths: {} as FieldTextPaths,
+    };
+  }
+
+  const mappings = await Promise.all(
+    displayFieldPaths.map((fieldPath) =>
+      buildDisplayTextStage(fieldPath, fields, context)
+    )
+  );
+
+  return mappings.reduce(
+    (acc, mapping) => {
+      if (!mapping) {
+        return acc;
+      }
+
+      acc.stages.push(mapping.step);
+      acc.fieldTextPaths[mapping.fieldPath] = mapping.targetPath;
+      return acc;
+    },
+    {
+      stages: [] as PipelineStage.AddFields[],
+      fieldTextPaths: {} as FieldTextPaths,
+    }
+  );
+};
+
+/**
+ * Creates the pipeline stage for a 'today' operation.
  *
  * @param operator The operator for the operation, if any
  * @param path The current path in the recursion
- * @returns The stage for the operation and an array with dependencies for the operation
+ * @param fieldTextPaths Pre-computed paths for `:text` field references
+ * @returns The stage for the operation and an array with dependencies
  */
-const resolveTodayOperator = (operator: Operator | null, path: string) => {
+const resolveTodayOperator = (
+  operator: Operator | null,
+  path: string,
+  fieldTextPaths: FieldTextPaths
+) => {
   const dependencies: Dependency[] = [];
 
   const getValueString = () => {
-    const value = getSimpleOperatorValue(operator);
-    if (!isNil(value)) return value; // check that not null or undefined, so 0 works
+    if (!operator) return null;
 
-    // if is an expression, add to dependencies array,
-    // that will be resolved before, since will be appended
-    // to the beginning of the pipeline
+    if (!isExpressionOperator(operator)) {
+      return getSimpleOperatorValue(operator, fieldTextPaths);
+    }
+
     const auxPath = `${path}-today`;
     dependencies.unshift({
-      operation: operator.value as Operation,
+      operation: operator.value,
       path: auxPath.startsWith('aux.') ? auxPath.slice(4) : auxPath,
     });
+
     return `$${auxPath.startsWith('aux.') ? '' : 'aux.'}${auxPath}`;
   };
 
@@ -111,32 +586,32 @@ const resolveTodayOperator = (operator: Operator | null, path: string) => {
 };
 
 /**
- * Creates the pipeline stage for an operation with a single operator
+ * Creates the pipeline stage for an operation with a single operator.
  *
  * @param operation The operation to resolve
  * @param operator The operator for the operation
  * @param path The current path in the recursion
  * @param timeZone the current timezone of the user
- * @returns The stage for the operation and an array with dependencies for the operation
+ * @param fieldTextPaths Pre-computed paths for `:text` field references
+ * @returns The stage for the operation and an array with dependencies
  */
 const resolveSingleOperator = (
   operation: SingleOperatorOperationsTypes,
   operator: Operator,
   path: string,
-  timeZone: string
+  timeZone: string,
+  fieldTextPaths: FieldTextPaths
 ) => {
   const dependencies: Dependency[] = [];
 
   const getValueString = () => {
-    const value = getSimpleOperatorValue(operator);
-    if (!isNil(value)) return value; // check that not null or undefined, so 0 works
+    if (!isExpressionOperator(operator)) {
+      return getSimpleOperatorValue(operator, fieldTextPaths);
+    }
 
-    // if is an expression, add to dependencies array,
-    // that will be resolved before, since will be appended
-    // to the beginning of the pipeline
     const auxPath = `${path}-${operation}`;
     dependencies.unshift({
-      operation: operator.value as Operation,
+      operation: operator.value,
       path: auxPath.startsWith('aux.') ? auxPath.slice(4) : auxPath,
     });
     return `$${auxPath.startsWith('aux.') ? '' : 'aux.'}${auxPath}`;
@@ -148,7 +623,6 @@ const resolveSingleOperator = (
     case 'exists':
     case 'toInt':
     case 'toLong': {
-      // Simple operations
       step = {
         $addFields: {
           [path.startsWith('aux.') ? path : `data.${path}`]: {
@@ -159,7 +633,6 @@ const resolveSingleOperator = (
       break;
     }
     case 'size': {
-      // Size operation
       step = {
         $addFields: {
           [path.startsWith('aux.') ? path : `data.${path}`]: {
@@ -176,7 +649,6 @@ const resolveSingleOperator = (
       break;
     }
     case 'date': {
-      // To date operation
       step = {
         $addFields: {
           [path.startsWith('aux.') ? path : `data.${path}`]: {
@@ -200,7 +672,6 @@ const resolveSingleOperator = (
     case 'minute':
     case 'second':
     case 'millisecond': {
-      // Date operations
       step = {
         $addFields: {
           [path.startsWith('aux.') ? path : `data.${path}`]: {
@@ -229,35 +700,37 @@ const resolveSingleOperator = (
 };
 
 /**
- * Creates the pipeline stage for an operation with a single operator
+ * Creates the pipeline stage for an operation with two operators.
  *
  * @param operation The operation to resolve
  * @param operator1 The first operator for the operation
  * @param operator2 The second operator for the operation
  * @param path The current path in the recursion
- * @returns The stage for the operation and an array with dependencies for the operation
+ * @param fieldTextPaths Pre-computed paths for `:text` field references
+ * @returns The stage for the operation and an array with dependencies
  */
 const resolveDoubleOperator = (
   operation: DoubleOperatorOperationsTypes,
   operator1: Operator,
   operator2: Operator,
-  path: string
+  path: string,
+  fieldTextPaths: FieldTextPaths
 ) => {
   const dependencies: Dependency[] = [];
 
   const getValueString = (i: number) => {
     const selectedOperator = i === 1 ? operator1 : operator2;
-    const value = getSimpleOperatorValue(selectedOperator);
-    if (!isNil(value)) return value; // check that not null or undefined, so 0 works
 
-    // if is an expression, add to dependencies array,
-    // that will be resolved before, since will be appended
-    // to the beginning of the pipeline
+    if (!isExpressionOperator(selectedOperator)) {
+      return getSimpleOperatorValue(selectedOperator, fieldTextPaths);
+    }
+
     const auxPath = `${path}-${operation}${i}`;
     dependencies.unshift({
-      operation: selectedOperator.value as Operation,
+      operation: selectedOperator.value,
       path: auxPath.startsWith('aux.') ? auxPath.slice(4) : auxPath,
     });
+
     return `$${auxPath.startsWith('aux.') ? '' : 'aux.'}${auxPath}`;
   };
 
@@ -265,7 +738,6 @@ const resolveDoubleOperator = (
 
   switch (operation) {
     case 'datediff':
-      // Date diff operation (always in minutes, can be converted to other units in the display options)
       step = {
         $addFields: {
           [path.startsWith('aux.') ? path : `data.${path}`]: {
@@ -279,9 +751,6 @@ const resolveDoubleOperator = (
       };
       break;
     case 'includes':
-      // Includes operation
-
-      // Add check if the value is an array, if not, evaluate to false
       step = {
         $addFields: {
           [path.startsWith('aux.') ? path : `data.${path}`]: {
@@ -297,7 +766,6 @@ const resolveDoubleOperator = (
       };
       break;
     default:
-      // Simple operations
       step = {
         $addFields: {
           [path.startsWith('aux.') ? path : `data.${path}`]: {
@@ -311,17 +779,19 @@ const resolveDoubleOperator = (
 };
 
 /**
- * Creates the pipeline stage for an operation with multiple operators
+ * Creates the pipeline stage for an operation with multiple operators.
  *
  * @param operation The operation to resolve
  * @param operators The operators for the operation
  * @param path The current path in the recursion
- * @returns The stage for the operation and an array with dependencies for the operation
+ * @param fieldTextPaths Pre-computed paths for `:text` field references
+ * @returns The stage for the operation and an array with dependencies
  */
 const resolveMultipleOperators = (
   operation: MultipleOperatorsOperationsTypes,
   operators: Operator[],
-  path: string
+  path: string,
+  fieldTextPaths: FieldTextPaths
 ) => {
   const dependencies: Dependency[] = [];
 
@@ -329,23 +799,19 @@ const resolveMultipleOperators = (
     $addFields: {
       [path.startsWith('aux.') ? path : `data.${path}`]: {
         [operationMap[operation]]: operators.map((operator, index) => {
-          let value = getSimpleOperatorValue(operator);
+          let value = getSimpleOperatorValue(operator, fieldTextPaths);
 
-          if (value === null) {
-            // if is an expression, add to dependencies array,
-            // that will be resolved before, since will be appended
-            // to the beginning of the pipeline
+          if (isExpressionOperator(operator)) {
             const auxPath = `${path}-${operation}${index}`;
             value = `$${auxPath.startsWith('aux.') ? '' : 'aux.'}${auxPath}`;
             dependencies.unshift({
-              operation: operator.value as Operation,
+              operation: operator.value,
               path: auxPath.startsWith('aux.') ? auxPath.slice(4) : auxPath,
             });
           }
 
           switch (operation) {
             case 'concat': {
-              // converts the value to a string (checks for date) if the operation is concat
               if (typeof value === 'string' && value.startsWith('$')) {
                 return {
                   $cond: {
@@ -366,16 +832,16 @@ const resolveMultipleOperators = (
                     },
                   },
                 };
-              } else {
-                return {
-                  $convert: {
-                    input: value,
-                    to: 'string',
-                    onError: '',
-                    onNull: '',
-                  },
-                };
               }
+
+              return {
+                $convert: {
+                  input: value,
+                  to: 'string',
+                  onError: '',
+                  onNull: '',
+                },
+              };
             }
             default: {
               return value;
@@ -390,16 +856,23 @@ const resolveMultipleOperators = (
 };
 
 /**
- * Gets the pipeline for a calculated field from its operation
+ * Gets the pipeline for a calculated field from its operation.
  *
- * @param op The operation that results in the calculated field
+ * @param operation The operation that results in the calculated field
  * @param path The current path in the recursion
  * @param timeZone the current timezone of the user
+ * @param fieldTextPaths Pre-computed paths for `:text` field references
  * @returns The pipeline for the calculated field
  */
-const buildPipeline = (op: Operation, path: string, timeZone: string) => {
+const buildPipeline = (
+  operation: Operation,
+  path: string,
+  timeZone: string,
+  fieldTextPaths: FieldTextPaths
+) => {
   const pipeline: PipelineStage.AddFields[] = [];
-  switch (op.operation) {
+
+  switch (operation.operation) {
     case 'add':
     case 'mul':
     case 'and':
@@ -408,20 +881,28 @@ const buildPipeline = (op: Operation, path: string, timeZone: string) => {
     case 'substr':
     case 'concat': {
       const { step, dependencies } = resolveMultipleOperators(
-        op.operation,
-        op.operators,
-        path
+        operation.operation,
+        operation.operators,
+        path,
+        fieldTextPaths
       );
 
-      if (dependencies.length > 0)
+      if (dependencies.length > 0) {
         pipeline.unshift(
           ...flattenDeep(
-            dependencies.map((dep) =>
-              buildPipeline(dep.operation, `aux.${dep.path}`, timeZone)
+            dependencies.map((dependency) =>
+              buildPipeline(
+                dependency.operation,
+                `aux.${dependency.path}`,
+                timeZone,
+                fieldTextPaths
+              )
             )
           )
         );
-      pipeline.push(step);
+      }
+
+      pipeline.push(step as PipelineStage.AddFields);
       break;
     }
     case 'sub':
@@ -435,21 +916,29 @@ const buildPipeline = (op: Operation, path: string, timeZone: string) => {
     case 'datediff':
     case 'includes': {
       const { step, dependencies } = resolveDoubleOperator(
-        op.operation,
-        op.operator1,
-        op.operator2,
-        path
+        operation.operation,
+        operation.operator1,
+        operation.operator2,
+        path,
+        fieldTextPaths
       );
 
-      if (dependencies.length > 0)
+      if (dependencies.length > 0) {
         pipeline.unshift(
           ...flattenDeep(
-            dependencies.map((dep) =>
-              buildPipeline(dep.operation, `aux.${dep.path}`, timeZone)
+            dependencies.map((dependency) =>
+              buildPipeline(
+                dependency.operation,
+                `aux.${dependency.path}`,
+                timeZone,
+                fieldTextPaths
+              )
             )
           )
         );
-      pipeline.push(step);
+      }
+
+      pipeline.push(step as PipelineStage.AddFields);
       break;
     }
     case 'year':
@@ -465,34 +954,54 @@ const buildPipeline = (op: Operation, path: string, timeZone: string) => {
     case 'toInt':
     case 'toLong': {
       const { step, dependencies } = resolveSingleOperator(
-        op.operation,
-        op.operator,
+        operation.operation,
+        operation.operator,
         path,
-        timeZone
+        timeZone,
+        fieldTextPaths
       );
-      if (dependencies.length > 0)
+
+      if (dependencies.length > 0) {
         pipeline.unshift(
           ...flattenDeep(
-            dependencies.map((dep) =>
-              buildPipeline(dep.operation, `aux.${dep.path}`, timeZone)
+            dependencies.map((dependency) =>
+              buildPipeline(
+                dependency.operation,
+                `aux.${dependency.path}`,
+                timeZone,
+                fieldTextPaths
+              )
             )
           )
         );
-      pipeline.push(step);
+      }
+
+      pipeline.push(step as PipelineStage.AddFields);
       break;
     }
     case 'today': {
-      const { step, dependencies } = resolveTodayOperator(op.operator, path);
+      const { step, dependencies } = resolveTodayOperator(
+        operation.operator,
+        path,
+        fieldTextPaths
+      );
 
-      if (dependencies.length > 0)
+      if (dependencies.length > 0) {
         pipeline.unshift(
           ...flattenDeep(
-            dependencies.map((dep) =>
-              buildPipeline(dep.operation, `aux.${dep.path}`, timeZone)
+            dependencies.map((dependency) =>
+              buildPipeline(
+                dependency.operation,
+                `aux.${dependency.path}`,
+                timeZone,
+                fieldTextPaths
+              )
             )
           )
         );
-      pipeline.push(step);
+      }
+
+      pipeline.push(step as PipelineStage.AddFields);
       break;
     }
   }
@@ -501,21 +1010,46 @@ const buildPipeline = (op: Operation, path: string, timeZone: string) => {
 };
 
 /**
- * Gets the pipeline for a calculated field from its operation expression
+ * Gets the pipeline for a calculated field from its operation expression.
  *
  * @param expression The operation expression of the calculated field
  * @param name The name of the calculated field
  * @param timeZone the current timezone of the user
+ * @param options Additional context required to resolve `:text` operators
  * @returns The pipeline for the calculated field
  */
-const buildCalculatedFieldPipeline = (
+const buildCalculatedFieldPipeline = async (
   expression: string,
   name: string,
-  timeZone: string
+  timeZone: string,
+  options: BuildCalculatedFieldPipelineOptions = {}
 ) => {
+  const rootOperator = getOperatorFromString(expression);
+  const { stages, fieldTextPaths } = await buildDisplayTextStagesFromOperator(
+    rootOperator,
+    options.fields,
+    options.context
+  );
+
+  if (!isExpressionOperator(rootOperator)) {
+    return [
+      ...stages,
+      {
+        $addFields: {
+          [`data.${name}`]: getSimpleOperatorValue(
+            rootOperator,
+            fieldTextPaths
+          ),
+        },
+      },
+    ];
+  }
+
   const operation = getExpressionFromString(expression);
-  const pipeline = buildPipeline(operation, name, timeZone);
-  return pipeline;
+  return [
+    ...stages,
+    ...buildPipeline(operation, name, timeZone, fieldTextPaths),
+  ];
 };
 
 export default buildCalculatedFieldPipeline;

--- a/src/utils/aggregation/expressionFromString.ts
+++ b/src/utils/aggregation/expressionFromString.ts
@@ -1,4 +1,5 @@
 import {
+  FieldOperatorValue,
   Operation,
   SingleOperatorOperationsTypes,
   DoubleOperatorOperationsTypes,
@@ -193,6 +194,25 @@ const getArgs = (exp: string): string[] => {
 };
 
 /**
+ * Parses a field reference, including its optional display modifier.
+ *
+ * @param exp The field expression without the `data.` prefix
+ * @returns Parsed field reference
+ */
+const parseFieldReference = (exp: string): FieldOperatorValue => {
+  if (exp.endsWith(':text')) {
+    return {
+      field: exp.slice(0, -5),
+      display: 'text',
+    };
+  }
+
+  return {
+    field: exp,
+  };
+};
+
+/**
  * Parses a string into an operation
  *
  * @param exp The expression to parse
@@ -228,7 +248,7 @@ const solveExp = (exp: string): Operator => {
   if (exp.startsWith('data.')) {
     return {
       type: 'field',
-      value: exp.substring(5),
+      value: parseFieldReference(exp.substring(5)),
     };
   }
 
@@ -299,12 +319,22 @@ const solveExp = (exp: string): Operator => {
 };
 
 /**
+ * Parses an expression string into its root operator.
+ *
+ * @param expression The raw expression string
+ * @returns The parsed root operator
+ */
+export const getOperatorFromString = (expression: string): Operator => {
+  expression = expression.trim();
+  return solveExp(expression);
+};
+
+/**
  * Transforms an operation expression into the Operation structure
  *
  * @param expression The operation expression of the calculated field in string format
  * @returns The operation expression of the calculated field in Operation format
  */
 export const getExpressionFromString = (expression: string): Operation => {
-  expression = expression.trim();
-  return solveExp(expression).value as Operation;
+  return getOperatorFromString(expression).value as Operation;
 };

--- a/src/utils/context/getContextData.ts
+++ b/src/utils/context/getContextData.ts
@@ -99,11 +99,15 @@ export const getContextDataForRecord = async (
           },
         },
         // Stages for calculating the field
-        ...buildCalculatedFieldPipeline(
+        ...(await buildCalculatedFieldPipeline(
           field.expression,
           field.name,
-          context.timeZone
-        ),
+          context.timeZone,
+          {
+            fields,
+            context,
+          }
+        )),
       ];
 
       const result = await Record.aggregate(pipeline);

--- a/src/utils/files/resourceExporter.ts
+++ b/src/utils/files/resourceExporter.ts
@@ -310,11 +310,12 @@ export default class Exporter {
     const pageSize = 100;
     for (let i = 0; i < totalCount; i += pageSize) {
       recordsPromises.push(
-        Record.aggregate(
-          this.buildPipeline(this.columns, ids.slice(i, i + pageSize))
-        ).then((items) => {
-          records.splice(i, items.length, ...items);
-        })
+        this.buildPipeline(this.columns, ids.slice(i, i + pageSize)).then(
+          (pipeline) =>
+            Record.aggregate(pipeline).then((items) => {
+              records.splice(i, items.length, ...items);
+            })
+        )
       );
     }
     // Execute all promises
@@ -342,12 +343,12 @@ export default class Exporter {
         // Reversed relationship, the resource is used in another resource's template
         if (column.parent) {
           relatedResourcePromises.push(
-            Record.aggregate(this.buildReversedPipeline(column, record)).then(
-              (relatedRecords) => {
+            this.buildReversedPipeline(column, record).then((pipeline) =>
+              Record.aggregate(pipeline).then((relatedRecords) => {
                 if (relatedRecords.length > 0) {
                   set(record, column.field, relatedRecords);
                 }
-              }
+              })
             )
           );
         } else {
@@ -421,17 +422,21 @@ export default class Exporter {
       { $match: filters },
       { $limit: this.params.limit || Number.MAX_SAFE_INTEGER },
     ];
-    this.columns
-      .filter((col) => col.meta?.field?.isCalculated)
-      .forEach((col) =>
-        pipeline.unshift(
-          ...(buildCalculatedFieldPipeline(
-            col.meta.field.expression,
-            col.meta.field.name,
-            this.params.timeZone
-          ) as any)
-        )
+    for (const column of this.columns.filter(
+      (candidate) => candidate.meta?.field?.isCalculated
+    )) {
+      pipeline.unshift(
+        ...(await buildCalculatedFieldPipeline(
+          column.meta.field.expression,
+          column.meta.field.name,
+          this.params.timeZone,
+          {
+            fields: this.resource.fields,
+            context,
+          }
+        ))
       );
+    }
     return pipeline;
   };
 
@@ -442,7 +447,7 @@ export default class Exporter {
    * @param ids list of ids, used in the case of subcolumns (resource and resources)
    * @returns a built pipeline
    */
-  private buildPipeline = (
+  private buildPipeline = async (
     columns: Column[],
     ids: mongoose.Types.ObjectId[]
   ) => {
@@ -498,17 +503,21 @@ export default class Exporter {
         },
       },
     ];
-    columns
-      .filter((col) => col.meta?.field?.isCalculated)
-      .forEach((col) =>
-        pipeline.unshift(
-          ...(buildCalculatedFieldPipeline(
-            col.meta.field.expression,
-            col.meta.field.name,
-            this.params.timeZone
-          ) as any)
-        )
+    for (const column of columns.filter(
+      (candidate) => candidate.meta?.field?.isCalculated
+    )) {
+      pipeline.unshift(
+        ...(await buildCalculatedFieldPipeline(
+          column.meta.field.expression,
+          column.meta.field.name,
+          this.params.timeZone,
+          {
+            fields: this.resource.fields,
+            context: this.req.context,
+          }
+        ))
       );
+    }
     return pipeline;
   };
 
@@ -519,7 +528,7 @@ export default class Exporter {
    * @param record current record
    * @returns reversed pipeline
    */
-  private buildReversedPipeline = (column: Column, record: any) => {
+  private buildReversedPipeline = async (column: Column, record: any) => {
     const relatedFieldName = column.parent.fields.find(
       (field) => field.relatedName === column.field
     )?.name;
@@ -569,17 +578,21 @@ export default class Exporter {
       },
       projectStep,
     ];
-    subColumns
-      .filter((col) => col.meta?.field?.isCalculated)
-      .forEach((col) =>
-        pipeline.unshift(
-          ...(buildCalculatedFieldPipeline(
-            col.meta.field.expression,
-            col.meta.field.name,
-            this.params.timeZone
-          ) as any)
-        )
+    for (const subColumn of subColumns.filter(
+      (candidate) => candidate.meta?.field?.isCalculated
+    )) {
+      pipeline.unshift(
+        ...(await buildCalculatedFieldPipeline(
+          subColumn.meta.field.expression,
+          subColumn.meta.field.name,
+          this.params.timeZone,
+          {
+            fields: column.parent?.fields || [],
+            context: this.req.context,
+          }
+        ))
       );
+    }
     return pipeline;
   };
 
@@ -1057,35 +1070,35 @@ export default class Exporter {
       //     )) ||
       //   mongoose.Types.ObjectId.isValid(columnValue)
       // )
-      const relatedPromises = Record.aggregate(
-        this.buildPipeline(
-          subColumns,
-          isArray(columnValue)
-            ? Array.from(new Set(columnValue))
-                .filter((id: any) => mongoose.Types.ObjectId.isValid(id))
-                .map((id: any) => new mongoose.Types.ObjectId(id))
-            : [new mongoose.Types.ObjectId(columnValue)]
-        )
-      ).then(async (relatedRecords) => {
-        if (relatedRecords.length > 0) {
-          set(
-            record,
-            fieldName,
-            isArray(columnValue) ? relatedRecords : relatedRecords[0]
-          );
-          for (let i = 0; i < columnValue.length; i++) {
-            await Promise.all(
-              subColumnsWithDisplay.map((subColumn) =>
-                this.getResourceFields(
-                  subColumn,
-                  `${fieldName}[${i}].${subColumn.field.split('.')[0]}`,
-                  record
-                )
-              )
+      const relatedPromises = this.buildPipeline(
+        subColumns,
+        isArray(columnValue)
+          ? Array.from(new Set(columnValue))
+              .filter((id: any) => mongoose.Types.ObjectId.isValid(id))
+              .map((id: any) => new mongoose.Types.ObjectId(id))
+          : [new mongoose.Types.ObjectId(columnValue)]
+      ).then((pipeline) =>
+        Record.aggregate(pipeline).then(async (relatedRecords) => {
+          if (relatedRecords.length > 0) {
+            set(
+              record,
+              fieldName,
+              isArray(columnValue) ? relatedRecords : relatedRecords[0]
             );
+            for (let i = 0; i < columnValue.length; i++) {
+              await Promise.all(
+                subColumnsWithDisplay.map((subColumn) =>
+                  this.getResourceFields(
+                    subColumn,
+                    `${fieldName}[${i}].${subColumn.field.split('.')[0]}`,
+                    record
+                  )
+                )
+              );
+            }
           }
-        }
-      });
+        })
+      );
       return relatedPromises;
     }
   };

--- a/src/utils/form/getDisplayText.ts
+++ b/src/utils/form/getDisplayText.ts
@@ -3,6 +3,8 @@ import { CustomAPI } from '../../server/apollo/dataSources';
 import config from 'config';
 import { logger } from '@services/logger.service';
 import axios, { AxiosHeaders, AxiosStatic } from 'axios';
+import { referenceDataType } from '@const/enumTypes';
+import { ReferenceData } from '@models';
 import get from 'lodash/get';
 import jsonpath from 'jsonpath';
 import commonServices from '@server/common-services';
@@ -155,6 +157,39 @@ export const getFullChoices = async (
         choices.push({ [valueField]: 'other', [textField]: 'Other' });
       }
       return choices;
+    } else if (field.referenceData?.id) {
+      const referenceData = await ReferenceData.findById(
+        field.referenceData.id
+      ).populate({
+        path: 'apiConfiguration',
+        model: 'ApiConfiguration',
+        select: { name: 1, endpoint: 1, graphQLEndpoint: 1 },
+      });
+
+      if (!referenceData) {
+        return field.choices || [];
+      }
+
+      let items: any[] = [];
+      if (referenceData.type !== referenceDataType.static) {
+        const dataSource: CustomAPI =
+          context.dataSources[(referenceData.apiConfiguration as any)?.name];
+        if (dataSource) {
+          items = await dataSource.getReferenceDataItems(
+            referenceData,
+            referenceData.apiConfiguration as any
+          );
+        }
+      } else {
+        items = referenceData.data;
+      }
+
+      const displayField =
+        field.referenceData.displayField || referenceData.valueField;
+      return items.map((item) => ({
+        value: get(item, referenceData.valueField),
+        text: get(item, displayField),
+      }));
     } else {
       return field.choices;
     }

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -355,6 +355,12 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
       // only add calculated fields that are in the query
       // in order to decrease the pipeline size
       const shouldAddCalculatedFieldToPipeline = (field: any) => {
+        // If the generic `data` payload is requested, calculated fields must be
+        // materialized into parent.data so records tables can display them.
+        if (queryFields.findIndex((x) => x.name === 'data') > -1) {
+          return true;
+        }
+
         // If field is requested in the query
         if (queryFields.findIndex((x) => x.name === field.name) > -1)
           return true;
@@ -377,17 +383,23 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
         return false;
       };
 
-      fields
-        .filter((f) => f.isCalculated && shouldAddCalculatedFieldToPipeline(f))
-        .forEach((f) =>
-          calculatedFieldsAggregation.push(
-            ...buildCalculatedFieldPipeline(
-              f.expression,
-              f.name,
-              context.timeZone
-            )
-          )
+      for (const field of fields.filter(
+        (candidate) =>
+          candidate.isCalculated &&
+          shouldAddCalculatedFieldToPipeline(candidate)
+      )) {
+        calculatedFieldsAggregation.push(
+          ...(await buildCalculatedFieldPipeline(
+            field.expression,
+            field.name,
+            context.timeZone,
+            {
+              fields,
+              context,
+            }
+          ))
         );
+      }
 
       // Build linked records aggregations
       const linkedReferenceDataAggregation = flatten(


### PR DESCRIPTION
# Description

Calculated fields and form expressions were inconsistent. This change adds ":text" support to the expression parser and calculated-field pipeline, resolves choice labels for plain choices and reference data, and carries that logic through the main record read paths, exports, aggregations, and survey helpers.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/129193/

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (refactor or addition to existing functionality)

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules