### PR TITLE
AB#134288 - ABC - Fields with choices translated must also translate in widgets / exports

### DIFF
--- a/__tests__/unit-tests/services/calculatedField.service.spec.ts
+++ b/__tests__/unit-tests/services/calculatedField.service.spec.ts
@@ -775,6 +775,31 @@ describe('CalculatedFieldService', () => {
       expect(stage.$let.in.$cond.if).toEqual({ $isArray: '$data.country' });
     });
 
+    it('uses localized static choice labels in the lookup stage', async () => {
+      const localizedResource = {
+        name: 'tasks',
+        fields: [
+          {
+            name: 'status',
+            choices: [
+              {
+                value: 'open',
+                text: { default: 'Open', en: 'Open', fr: 'Ouvert' },
+              },
+            ],
+          },
+        ],
+      };
+      const pipeline = await new CalculatedFieldService(
+        localizedResource,
+        { locale: 'fr' } as any,
+        'UTC'
+      ).build("{{calc.displayValue('status')}}", 'result');
+
+      const stage = (pipeline[0] as any).$addFields['data.result'];
+      expect(stage.$let.vars.dvTexts).toEqual(['Ouvert']);
+    });
+
     it('normalizes numeric choice values and coerces the stored value to string so 4 matches "4"', async () => {
       const numericResource = {
         name: 'tasks',

--- a/__tests__/unit-tests/utils/files/convertUrlToBase64.spec.ts
+++ b/__tests__/unit-tests/utils/files/convertUrlToBase64.spec.ts
@@ -5,6 +5,7 @@ import { convertUrlToBase64 } from '@utils/files';
 jest.mock('axios');
 jest.mock('@services/logger.service');
 
+/** Mocked axios client for request assertions. */
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe('convertUrlToBase64', () => {

--- a/__tests__/unit-tests/utils/form/getDisplayText.spec.ts
+++ b/__tests__/unit-tests/utils/form/getDisplayText.spec.ts
@@ -1,0 +1,63 @@
+import {
+  getFullChoices,
+  getLocalizedText,
+  getText,
+} from '@utils/form/getDisplayText';
+
+describe('getDisplayText utilities', () => {
+  const choices = [
+    {
+      value: 'open',
+      text: {
+        default: 'Open',
+        en: 'Open',
+        fr: 'Ouvert',
+        uk: 'Відкрито',
+      },
+    },
+    {
+      value: 'closed',
+      text: {
+        default: 'Closed',
+        en: 'Closed',
+      },
+    },
+  ];
+
+  it('returns the choice label for the requested language', () => {
+    expect(getText(choices, 'open', 'fr')).toBe('Ouvert');
+  });
+
+  it('returns the choice label for Ukrainian', () => {
+    expect(getText(choices, 'open', 'uk')).toBe('Відкрито');
+  });
+
+  it('falls back to default labels when the requested language is missing', () => {
+    expect(getText(choices, 'closed', 'fr')).toBe('Closed');
+  });
+
+  it('supports locale variants through their base language', () => {
+    expect(getLocalizedText(choices[0].text, 'fr_CA', 'open')).toBe('Ouvert');
+  });
+
+  it('supports Ukrainian locale variants through their base language', () => {
+    expect(getLocalizedText(choices[0].text, 'uk_UA', 'open')).toBe('Відкрито');
+  });
+
+  it('can preserve dynamic choice text behavior without locale localization', () => {
+    expect(getText(choices, 'open', 'uk', false)).toBe('Open');
+  });
+
+  it('keeps the stored value when no matching choice exists', () => {
+    expect(getText(choices, 'unknown', 'fr')).toBe('unknown');
+  });
+
+  it('localizes static choices returned by getFullChoices', async () => {
+    await expect(
+      getFullChoices({ choices }, { locale: 'fr' } as any)
+    ).resolves.toEqual([
+      { value: 'open', text: 'Ouvert' },
+      { value: 'closed', text: 'Closed' },
+    ]);
+  });
+});

--- a/src/routes/download/index.ts
+++ b/src/routes/download/index.ts
@@ -141,7 +141,8 @@ router.get('/form/records/:id', async (req, res) => {
         const records = await Record.find(filter);
         const rows = await getRows(
           columns,
-          getAccessibleFields(records, formAbility)
+          getAccessibleFields(records, formAbility),
+          req.context?.locale
         );
         const type = (req.query ? req.query.type : 'xlsx').toString();
         const filename = formatFilename(form.name);
@@ -318,7 +319,7 @@ router.get('/resource/records/:id', async (req, res) => {
             archived: { $ne: true },
           });
         }
-        const rows = await getRows(columns, records);
+        const rows = await getRows(columns, records, req.context?.locale);
         const type = (req.query ? req.query.type : 'xlsx').toString();
         const filename = formatFilename(resource.name);
         return await fileBuilder(res, filename, columns, rows, type);

--- a/src/server/apollo/context.ts
+++ b/src/server/apollo/context.ts
@@ -12,6 +12,7 @@ export interface Context {
   accesstoken?: string;
   i18next: any;
   timeZone: string;
+  locale?: string;
 }
 
 /** User interface with specified AppAbility */

--- a/src/server/middlewares/rest.ts
+++ b/src/server/middlewares/rest.ts
@@ -3,6 +3,7 @@ import defineUserAbility from '@security/defineUserAbility';
 import { AuthenticationType } from '../../oort.config';
 import i18next from 'i18next';
 import config from 'config';
+import { getICULocale } from '@utils/date/getICULocale';
 
 /** Authentication strategy */
 const strategy =
@@ -20,7 +21,7 @@ const strategy =
 export const restMiddleware = (req, res, next) => {
   passport.authenticate(strategy, { session: true }, (err, user) => {
     if (user) {
-      req.context = { user };
+      req.context = { user, locale: getICULocale(req?.headers?.language) };
       // req.context.user = user;
       // Define the rights of the user
       req.context.user.ability = defineUserAbility(user);

--- a/src/services/calculatedField.service.ts
+++ b/src/services/calculatedField.service.ts
@@ -10,7 +10,7 @@ import {
 } from '@const/calculatedFields';
 import { referenceDataType } from '@const/enumTypes';
 import { getExpressionFromString } from '@utils/aggregation/expressionFromString';
-import { getFullChoices } from '@utils/form/getDisplayText';
+import { getFullChoices, getText } from '@utils/form/getDisplayText';
 import { ApiConfiguration, ReferenceData } from '@models';
 import { CustomAPI } from '@server/apollo/dataSources';
 import { Context } from '@server/apollo/context';
@@ -196,10 +196,19 @@ export class CalculatedFieldService {
       }
       if (field.choicesByUrl || field.choicesByGraphQL || field.choices) {
         const choices = await getFullChoices(field, this.context as any);
+        const localizeStaticChoices = Boolean(field.choices);
         return (choices || []).map((c: any) =>
           typeof c === 'string' || typeof c === 'number'
             ? { value: c, text: c }
-            : { value: c.value, text: c.text?.default ?? c.text ?? c.value }
+            : {
+                value: c.value,
+                text: getText(
+                  choices,
+                  c.value,
+                  this.context?.locale,
+                  localizeStaticChoices
+                ),
+              }
         );
       }
       return [];

--- a/src/utils/aggregation/setDisplayText.ts
+++ b/src/utils/aggregation/setDisplayText.ts
@@ -48,9 +48,13 @@ const setDisplayText = async (
     }
   };
   const fieldWithChoices = await mappedFields.reduce(reducer, {});
-  for (const [key, field] of Object.entries(fieldWithChoices)) {
+  for (const [key, field] of Object.entries(fieldWithChoices) as [
+    string,
+    any
+  ][]) {
     // Fetch choices from source ( static / rest / graphql )
     const choices = await getFullChoices(field, context);
+    const localizeStaticChoices = Boolean(field.choices);
     for (const item of items) {
       const fieldValue = get(item, key, null);
       if (fieldValue) {
@@ -60,8 +64,15 @@ const setDisplayText = async (
             item,
             key,
             isArray(fieldValue)
-              ? fieldValue.map((x) => getText(choices, x))
-              : getText(choices, fieldValue)
+              ? fieldValue.map((x) =>
+                  getText(choices, x, context?.locale, localizeStaticChoices)
+                )
+              : getText(
+                  choices,
+                  fieldValue,
+                  context?.locale,
+                  localizeStaticChoices
+                )
           );
         }
       } else {

--- a/src/utils/files/extractGridData.ts
+++ b/src/utils/files/extractGridData.ts
@@ -40,6 +40,7 @@ const getTotalCount = (
       headers: {
         Authorization: req.headers.authorization,
         'Content-Type': 'application/json',
+        ...(req.headers.language && { language: req.headers.language }),
         ...(req.headers.accesstoken && {
           accesstoken: req.headers.accesstoken,
         }),
@@ -79,6 +80,7 @@ const getColumns = (req: any, params: GridExtractParams): Promise<any[]> => {
       headers: {
         Authorization: req.headers.authorization,
         'Content-Type': 'application/json',
+        ...(req.headers.language && { language: req.headers.language }),
         ...(req.headers.accesstoken && {
           accesstoken: req.headers.accesstoken,
         }),
@@ -144,6 +146,7 @@ const getRows = async (
         headers: {
           Authorization: req.headers.authorization,
           'Content-Type': 'application/json',
+          ...(req.headers.language && { language: req.headers.language }),
           ...(req.headers.accesstoken && {
             accesstoken: req.headers.accesstoken,
           }),
@@ -171,7 +174,9 @@ const getRows = async (
                 rows.push(
                   ...getRowsFromMeta(
                     columns,
-                    data.data[field].edges.map((x) => x.node)
+                    data.data[field].edges.map((x) => x.node),
+                    false,
+                    req.context?.locale
                   )
                 );
               }

--- a/src/utils/files/getRows.ts
+++ b/src/utils/files/getRows.ts
@@ -7,11 +7,13 @@ import { getText } from '../form/getDisplayText';
  *
  * @param columns definition of export columns.
  * @param records list of records.
+ * @param locale Requested application locale.
  * @returns list of export rows.
  */
 export const getRows = async (
   columns: any[],
-  records: any[]
+  records: any[],
+  locale?: string
 ): Promise<any[]> => {
   const rows = [];
   for (const record of records) {
@@ -29,9 +31,9 @@ export const getRows = async (
             const choices = column.meta.field.choices || [];
             if (choices.length > 0) {
               if (Array.isArray(value)) {
-                value = value.map((x) => getText(choices, x));
+                value = value.map((x) => getText(choices, x, locale));
               } else {
-                value = getText(choices, value);
+                value = getText(choices, value, locale);
               }
             }
             set(
@@ -47,9 +49,9 @@ export const getRows = async (
           const choices = column.meta.field.choices || [];
           if (choices.length > 0) {
             if (Array.isArray(value)) {
-              value = value.map((x) => getText(choices, x));
+              value = value.map((x) => getText(choices, x, locale));
             } else {
-              value = getText(choices, value);
+              value = getText(choices, value, locale);
             }
           }
           set(row, column.name, Array.isArray(value) ? value.join(',') : value);

--- a/src/utils/files/getRowsFromMeta.ts
+++ b/src/utils/files/getRowsFromMeta.ts
@@ -10,8 +10,14 @@ import { Column } from './getColumnsFromMeta';
  * @param column Corresponding column.
  * @param data Data to set in row.
  * @param row Row to be updated.
+ * @param locale Requested application locale.
  */
-const setMultiselectRow = (column: any, data: any, row: any) => {
+const setMultiselectRow = (
+  column: any,
+  data: any,
+  row: any,
+  locale?: string
+) => {
   if (column.value) {
     const value = data[column.field]?.includes(column.value) ? 1 : 0;
     set(row, column.name, value);
@@ -22,9 +28,9 @@ const setMultiselectRow = (column: any, data: any, row: any) => {
       const choices = column.meta.field.choices || [];
       if (choices.length > 0) {
         if (Array.isArray(value)) {
-          value = value.map((x) => getText(choices, x));
+          value = value.map((x) => getText(choices, x, locale));
         } else {
-          value = getText(choices, value);
+          value = getText(choices, value, locale);
         }
       }
     }
@@ -39,12 +45,14 @@ const setMultiselectRow = (column: any, data: any, row: any) => {
  * @param columns definition of export columns.
  * @param records list of records.
  * @param isEmail boolean to account for email behaviour
+ * @param locale Requested application locale.
  * @returns list of export rows.
  */
 export const getRowsFromMeta = (
   columns: Column[],
   records: any[],
-  isEmail = false
+  isEmail = false,
+  locale?: string
 ): any[] => {
   const rows = [];
   for (const record of records) {
@@ -56,9 +64,9 @@ export const getRowsFromMeta = (
           const choices = column.meta.field.choices || [];
           if (choices.length > 0) {
             if (Array.isArray(value)) {
-              value = value.map((x) => getText(choices, x));
+              value = value.map((x) => getText(choices, x, locale));
             } else {
-              value = getText(choices, value);
+              value = getText(choices, value, locale);
             }
           }
           set(row, column.name, Array.isArray(value) ? value.join(',') : value);
@@ -69,9 +77,9 @@ export const getRowsFromMeta = (
           const choices = column.meta.field.choices || [];
           if (choices.length > 0) {
             if (Array.isArray(value)) {
-              value = value.map((x) => getText(choices, x));
+              value = value.map((x) => getText(choices, x, locale));
             } else {
-              value = getText(choices, value);
+              value = getText(choices, value, locale);
             }
           }
           set(row, column.name, Array.isArray(value) ? value.join(',') : value);
@@ -122,7 +130,7 @@ export const getRowsFromMeta = (
         }
         case 'checkbox':
         case 'tagbox': {
-          setMultiselectRow(column, record, row);
+          setMultiselectRow(column, record, row, locale);
           break;
         }
         case 'dropdown': {
@@ -132,9 +140,9 @@ export const getRowsFromMeta = (
             const choices = column.meta.field.choices || [];
             if (choices.length > 0) {
               if (Array.isArray(value)) {
-                value = value.map((x) => getText(choices, x));
+                value = value.map((x) => getText(choices, x, locale));
               } else {
-                value = getText(choices, value);
+                value = getText(choices, value, locale);
               }
             }
           }
@@ -160,11 +168,21 @@ export const getRowsFromMeta = (
           const value = get(record, column.field) || [];
           if ((column.subColumns || []).length > 0) {
             if (value && isArray(value)) {
-              const subRows = getRowsFromMeta(column.subColumns, value);
+              const subRows = getRowsFromMeta(
+                column.subColumns,
+                value,
+                isEmail,
+                locale
+              );
               set(row, column.name, subRows);
             }
           } else if (column.displayField) {
-            const subRows = getRowsFromMeta([column.displayField], value);
+            const subRows = getRowsFromMeta(
+              [column.displayField],
+              value,
+              isEmail,
+              locale
+            );
             const separator = column.displayField.separator;
             set(
               row,
@@ -238,7 +256,9 @@ export const getRowsFromMeta = (
           if (isEmail) {
             const radioValue = get(record, column.field);
             const choices = column?.meta?.field?.choices || [];
-            const text = choices?.length ? getText(choices, radioValue) : '';
+            const text = choices?.length
+              ? getText(choices, radioValue, locale)
+              : '';
             set(row, column.name, text || radioValue);
             break;
           }
@@ -263,7 +283,12 @@ export const getRowsFromMeta = (
           const value = get(record, column.field);
           if (column.subColumns) {
             if (value && isArray(value)) {
-              const subRows = getRowsFromMeta(column.subColumns, value);
+              const subRows = getRowsFromMeta(
+                column.subColumns,
+                value,
+                isEmail,
+                locale
+              );
               set(row, column.name, subRows);
             }
           } else {

--- a/src/utils/files/resourceExporter.ts
+++ b/src/utils/files/resourceExporter.ts
@@ -91,7 +91,9 @@ export default class Exporter {
       case 'xlsx': {
         const records: Record[] = getRowsFromMeta(
           this.columns,
-          await this.getRecords()
+          await this.getRecords(),
+          false,
+          this.req.context?.locale
         );
         let workbook: Workbook | stream.xlsx.WorkbookWriter;
         // Create a new instance of a Workbook class
@@ -123,7 +125,9 @@ export default class Exporter {
       case 'csv': {
         const records: Record[] = getRowsFromMeta(
           this.columns,
-          await this.getRecords()
+          await this.getRecords(),
+          false,
+          this.req.context?.locale
         );
         // Create a string array with the columns' labels or names as fallback, then construct the parser from it
         const fields = this.columns.flatMap((x) => ({
@@ -155,7 +159,8 @@ export default class Exporter {
         const records: Record[] = getRowsFromMeta(
           this.columns,
           await this.getRecords(),
-          true
+          true,
+          this.req.context?.locale
         );
         // Generate csv, by parsing the data
         const csvData = [];

--- a/src/utils/form/getDisplayText.ts
+++ b/src/utils/form/getDisplayText.ts
@@ -100,6 +100,7 @@ export const getLocalizedChoices = (
  * @param choices list of choices.
  * @param value choice value.
  * @param locale Requested application locale.
+ * @param localize Whether to localize choice labels.
  * @returns display value of the value.
  */
 export const getText = (

--- a/src/utils/form/getDisplayText.ts
+++ b/src/utils/form/getDisplayText.ts
@@ -8,26 +8,120 @@ import { JSONPath } from 'jsonpath-plus';
 import commonServices from '@server/common-services';
 import { AxiosCacheInstance } from 'axios-cache-interceptor';
 
+export type Choice =
+  | string
+  | number
+  | boolean
+  | {
+      value?: unknown;
+      text?: unknown;
+      [key: string]: unknown;
+    };
+
+/** Default language used when no locale is provided. */
+const DEFAULT_LANGUAGE = 'en';
+
+/**
+ * Gets the stored value represented by a choice definition.
+ *
+ * @param choice Choice definition.
+ * @returns Stored value of the choice.
+ */
+const getChoiceValue = (choice: Choice): unknown => {
+  if (choice && typeof choice === 'object' && 'value' in choice) {
+    return choice.value;
+  }
+  return choice;
+};
+
+/**
+ * Gets the localized label from a SurveyJS choice text object.
+ *
+ * @param text Choice text or localized text map.
+ * @param locale Requested application locale.
+ * @param fallback Fallback value when no label is available.
+ * @returns Localized choice label.
+ */
+export const getLocalizedText = (
+  text: unknown,
+  locale?: string,
+  fallback?: unknown
+): unknown => {
+  if (!text || typeof text !== 'object') {
+    return text ?? fallback;
+  }
+
+  const normalizedLocale = locale?.replace('-', '_') || DEFAULT_LANGUAGE;
+  const baseLanguage = normalizedLocale.split('_')[0];
+  const candidates = [
+    normalizedLocale,
+    normalizedLocale.replace('_', '-'),
+    baseLanguage,
+    'default',
+    DEFAULT_LANGUAGE,
+  ];
+
+  const localizedText = text as Record<string, unknown>;
+  for (const key of candidates) {
+    const value = localizedText[key];
+    if (value !== undefined && value !== null && value !== '') {
+      return value;
+    }
+  }
+
+  return fallback;
+};
+
+/**
+ * Localizes static choices without changing their stored values.
+ *
+ * @param choices Choice definitions.
+ * @param locale Requested application locale.
+ * @returns Choices with localized text.
+ */
+export const getLocalizedChoices = (
+  choices: Choice[] = [],
+  locale?: string
+): Choice[] =>
+  choices.map((choice) => {
+    if (choice && typeof choice === 'object' && 'text' in choice) {
+      const value = getChoiceValue(choice);
+      return {
+        ...choice,
+        text: getLocalizedText(choice.text, locale, value),
+      };
+    }
+    return choice;
+  });
+
 /**
  * Gets display text from choice value.
  *
  * @param choices list of choices.
  * @param value choice value.
+ * @param locale Requested application locale.
  * @returns display value of the value.
  */
-export const getText = (choices: any[], value: any): string => {
-  if (value) {
-    const choice = choices.find((x) =>
-      x.value
-        ? x.value.toString() === value.toString()
-        : x.toString() === value.toString()
-    );
+export const getText = (
+  choices: Choice[],
+  value: unknown,
+  locale?: string,
+  localize = true
+): unknown => {
+  if (value !== undefined && value !== null && value !== '') {
+    const choice = choices.find((x) => {
+      const choiceValue = getChoiceValue(x);
+      return choiceValue?.toString() === value.toString();
+    });
     if (choice != null) {
-      if (choice.text) {
-        if (choice.text.default) {
-          return choice.text.default;
+      if (typeof choice === 'object' && 'text' in choice) {
+        if (localize) {
+          return getLocalizedText(choice.text, locale, getChoiceValue(choice));
         }
-        return choice.text;
+        const text = choice.text as { default?: unknown } | unknown;
+        return text && typeof text === 'object' && 'default' in text
+          ? (text as { default?: unknown }).default
+          : text;
       }
       return choice;
     }
@@ -45,7 +139,7 @@ export const getText = (choices: any[], value: any): string => {
 export const getFullChoices = async (
   field: any,
   context: Context
-): Promise<{ value: string; text: string }[] | string[]> => {
+): Promise<Choice[]> => {
   try {
     if (field.choicesByUrl) {
       const url: string = field.choicesByUrl.url;
@@ -158,11 +252,11 @@ export const getFullChoices = async (
       }
       return choices;
     } else {
-      return field.choices;
+      return getLocalizedChoices(field.choices, context?.locale);
     }
   } catch (err) {
     logger.error(err.message, { stack: err.stack });
-    return field.choices;
+    return getLocalizedChoices(field.choices, context?.locale);
   }
 };
 
@@ -178,14 +272,16 @@ const getDisplayText = async (
   field: any,
   value: any,
   context: Context
-): Promise<string | string[]> => {
-  const choices: { value: string; text: string }[] | string[] =
-    await getFullChoices(field, context);
+): Promise<unknown | unknown[]> => {
+  const choices = await getFullChoices(field, context);
+  const localizeStaticChoices = Boolean(field.choices);
   if (choices && choices.length) {
     if (Array.isArray(value)) {
-      return value.map((x) => getText(choices, x));
+      return value.map((x) =>
+        getText(choices, x, context?.locale, localizeStaticChoices)
+      );
     } else {
-      return getText(choices, value);
+      return getText(choices, value, context?.locale, localizeStaticChoices);
     }
   }
   return value;

--- a/src/utils/history/recordHistory.ts
+++ b/src/utils/history/recordHistory.ts
@@ -15,7 +15,7 @@ import {
   startCase,
   isNil,
 } from 'lodash';
-import { getFullChoices } from '@utils/form';
+import { Choice, getFullChoices, getText } from '@utils/form';
 import { accessibleBy } from '@casl/mongoose';
 
 /**
@@ -299,12 +299,15 @@ export class RecordHistory {
   private async formatValues(history: RecordHistoryType) {
     const getOptionFromChoices = (
       value: string,
-      choices: { value: string; text: string }[] | string[]
+      choices: Choice[],
+      localizeStaticChoices: boolean
     ) => {
-      const choice = (choices as any[])?.find((c: any) =>
-        c.value ? c.value == value : c == value
+      return getText(
+        choices,
+        value,
+        this.options.context?.locale,
+        localizeStaticChoices
       );
-      return choice === undefined ? value : choice.text ? choice.text : choice;
     };
 
     const getReferenceData = async (id: string) =>
@@ -359,17 +362,22 @@ export class RecordHistory {
       } else {
         // Otherwise, get the display value from choices stored in the field/choicesByUrl
         const choices = await getFullChoices(field, this.options.context);
+        const localizeStaticChoices = Boolean(field.choices);
         if (change.old !== undefined) {
           if (isArray(change.old)) {
             change.old = [
               ...new Set(
                 change.old.map((item: string) =>
-                  getOptionFromChoices(item, choices)
+                  getOptionFromChoices(item, choices, localizeStaticChoices)
                 )
               ),
             ];
           } else {
-            change.old = getOptionFromChoices(change.old, choices);
+            change.old = getOptionFromChoices(
+              change.old,
+              choices,
+              localizeStaticChoices
+            );
           }
         }
         if (change.new !== undefined) {
@@ -377,12 +385,16 @@ export class RecordHistory {
             change.new = [
               ...new Set(
                 change.new.map((item: string) =>
-                  getOptionFromChoices(item, choices)
+                  getOptionFromChoices(item, choices, localizeStaticChoices)
                 )
               ),
             ];
           } else {
-            change.new = getOptionFromChoices(change.new, choices);
+            change.new = getOptionFromChoices(
+              change.new,
+              choices,
+              localizeStaticChoices
+            );
           }
         }
       }
@@ -520,11 +532,15 @@ export class RecordHistory {
                     switch (field.columns[i].cellType) {
                       case 'radiogroup':
                       case 'dropdown':
-                        newVal = getOptionFromChoices(newVal, field.choices);
+                        newVal = getOptionFromChoices(
+                          newVal,
+                          field.choices,
+                          true
+                        );
                         break;
                       case 'checkbox':
                         newVal = newVal.map((item: string) =>
-                          getOptionFromChoices(item, field.choices)
+                          getOptionFromChoices(item, field.choices, true)
                         );
                     }
                     Object.assign(change[state], {
@@ -546,7 +562,8 @@ export class RecordHistory {
                     const newKey = getTitleFromName(key, field.columns);
                     const newVal = getOptionFromChoices(
                       entry[key],
-                      field.choices
+                      field.choices,
+                      true
                     );
                     Object.assign(newEntry, { [newKey]: newVal });
                   }

--- a/src/utils/schema/resolvers/Query/getSortAggregation.ts
+++ b/src/utils/schema/resolvers/Query/getSortAggregation.ts
@@ -1,5 +1,5 @@
 import { MULTISELECT_TYPES } from '@const/fieldTypes';
-import { getFullChoices } from '../../../form';
+import { getFullChoices, getText } from '../../../form';
 import getSortField from './getSortField';
 import getSortOrder from './getSortOrder';
 
@@ -29,7 +29,20 @@ const getSortAggregation = async (
     field &&
     (field.choices || field.choicesByUrl || field.choicesByGraphQL)
   ) {
-    const choices = (await getFullChoices(field, context)) || [];
+    const fullChoices = (await getFullChoices(field, context)) || [];
+    const localizeStaticChoices = Boolean(field.choices);
+    const choices = fullChoices.map((choice: any) => {
+      const value = choice?.value ?? choice;
+      return {
+        value,
+        text: getText(
+          fullChoices,
+          value,
+          context?.locale,
+          localizeStaticChoices
+        ),
+      };
+    });
     const choicesValue = choices.map((x) => x.value);
     // Create aggregation to have text instead of values
     if (MULTISELECT_TYPES.includes(field.type)) {


### PR DESCRIPTION
# Description

Adds end-to-end localization support for static form-builder choice labels in English, French, and Ukrainian, while keeping stored answer values stable and language-independent.

The frontend now sends the selected app language to the backend through REST and GraphQL `Language` headers, synchronizes SurveyJS form locale with the app/profile language, and supports French and Ukrainian as available languages.

The backend now resolves localized static choice labels consistently across display/export paths, including forms, widgets/layouts, aggregations, sorting, calculated display values, record history, and CSV/XLSX exports. Dynamic/reference/API choices are intentionally left unchanged.

## Useful links

- Ticket: https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/134288/

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

The following checks were run locally:

- [x] Backend lint: `npm run lint`
- [x] Backend build: `npm run build`
- [x] Frontend lint: `NODE_OPTIONS="--max-old-space-size=4096" npx nx run-many --target=lint --projects=shared,front-office,back-office,ui,web-widgets`

Manual verification checklist:

- [x] Opened a form with static translated choices.
- [x] Verified static choice labels update when switching language between English, French, and Ukrainian.
- [x] Verified stored values remain unchanged and language-independent.
- [x] Verified SurveyJS form language follows the app/profile language.
- [x] Verified dropdown/tagbox inputs do not disappear after language changes.
- [x] Verified dynamic/reference/API-backed choices remain unchanged.

## Screenshots

<img width="2076" height="332" alt="image" src="https://github.com/user-attachments/assets/887087ab-d769-4c02-baa9-32068a6bcf2c" />

<img width="2053" height="287" alt="image" src="https://github.com/user-attachments/assets/0c87ea67-7a05-4357-a016-6b7b1b180b84" />

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules