### PR TITLE
AB#133554 ABC-email-notifications-in-app

### DIFF
--- a/__tests__/unit-tests/schema/mutation/addApplication.mutation.spec.ts
+++ b/__tests__/unit-tests/schema/mutation/addApplication.mutation.spec.ts
@@ -1,6 +1,6 @@
 import addApplication from '@schema/mutation/addApplication.mutation';
 import mongoose from 'mongoose';
-import { Application, Channel, Notification, Role } from '@models';
+import { Application, Channel, Role } from '@models';
 import pubsub from '@server/pubsub';
 import { DatabaseHelpers } from '../../../helpers/database-helpers';
 import { GraphQLError } from 'graphql';
@@ -123,24 +123,6 @@ describe('addApplication Resolver', () => {
         expect.any(mongoose.Types.ObjectId),
         expect.any(mongoose.Types.ObjectId),
       ]);
-    });
-  });
-
-  describe('Notification Logic', () => {
-    it('should create and save notification after application creation', async () => {
-      await addApplication.resolve(null, {}, context);
-      const notification = await Notification.findOne({
-        action: 'Application created',
-      });
-      expect(notification).toBeTruthy();
-    });
-
-    it('should publish notification to appropriate channel', async () => {
-      await addApplication.resolve(null, {}, context);
-      expect((await pubsub()).publish).toHaveBeenCalledWith(
-        expect.any(mongoose.Types.ObjectId),
-        expect.objectContaining({ notification: expect.any(Object) })
-      );
     });
   });
 

--- a/src/models/emailNotification.model.ts
+++ b/src/models/emailNotification.model.ts
@@ -83,6 +83,7 @@ export interface EmailNotification extends Document {
   restrictSubscription: boolean;
   emailLayout: mongoose.Schema.Types.ObjectId | CustomTemplate; // Reference to CustomTemplate;
   /** Pre-resolved recipient lists stored by the frontend before sending */
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- email header keys
   recipients?: { To: string[]; Cc: string[]; Bcc: string[] };
   recipientsType: string;
   status: string;

--- a/src/models/emailNotification.model.ts
+++ b/src/models/emailNotification.model.ts
@@ -82,6 +82,8 @@ export interface EmailNotification extends Document {
   subscriptionList: string[];
   restrictSubscription: boolean;
   emailLayout: mongoose.Schema.Types.ObjectId | CustomTemplate; // Reference to CustomTemplate;
+  /** Pre-resolved recipient lists stored by the frontend before sending */
+  recipients?: { To: string[]; Cc: string[]; Bcc: string[] };
   recipientsType: string;
   status: string;
   lastExecution?: Date;
@@ -158,6 +160,11 @@ export const emailNotificationSchema = new Schema<EmailNotification>(
     emailLayout: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'customTemplate', // Reference to CustomTemplate collection
+    },
+    recipients: {
+      To: [{ type: String }],
+      Cc: [{ type: String }],
+      Bcc: [{ type: String }],
     },
     recipientsType: {
       type: String,

--- a/src/models/notification.model.ts
+++ b/src/models/notification.model.ts
@@ -9,7 +9,10 @@ const notificationSchema = new Schema(
     channel: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'Channel',
-      required: true,
+    },
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
     },
     seenBy: {
       type: [mongoose.Schema.Types.ObjectId],
@@ -33,6 +36,7 @@ export interface Notification extends Document {
   content: any;
   createdAt: Date;
   channel: any;
+  user: any;
   seenBy: any[];
 }
 

--- a/src/routes/notification/index.ts
+++ b/src/routes/notification/index.ts
@@ -1,10 +1,11 @@
 import express from 'express';
 import { logger } from '@services/logger.service';
-import { EmailNotification } from '@models';
+import { EmailNotification, Notification, User } from '@models';
 import { azureFunctionHeaders } from '@utils/notification/util';
 import i18next from 'i18next';
 import axios from 'axios';
 import config from 'config';
+import pubsub from '@server/pubsub';
 
 /**
  * Send email using SMTP email client
@@ -125,6 +126,68 @@ router.post('/remove-subscription', async (req, res) => {
 });
 
 /**
+ * After sending an email notification, create in-app notifications for any
+ * recipient (To/Cc/Bcc) who is also a registered user.
+ *
+ * @param configId EmailNotification document id
+ * @param html Rendered HTML body returned by the Azure function
+ */
+const createInAppNotificationsForEmailRecipients = async (
+  configId: string,
+  html: string
+): Promise<void> => {
+  try {
+    const emailNotif = await EmailNotification.findById(configId)
+      .select('name recipients subscriptionList')
+      .lean()
+      .exec();
+    if (!emailNotif) return;
+
+    // Collect all recipient addresses: pre-resolved To/Cc/Bcc + opt-in list
+    const recipientEmails = [
+      ...(emailNotif.recipients?.To ?? []),
+      ...(emailNotif.recipients?.Cc ?? []),
+      ...(emailNotif.recipients?.Bcc ?? []),
+      ...(emailNotif.subscriptionList ?? []),
+    ];
+
+    if (!recipientEmails.length) return;
+
+    const uniqueEmails = [...new Set(recipientEmails)];
+    const users = await User.find({ username: { $in: uniqueEmails } }).select(
+      '_id'
+    );
+
+    if (!users.length) return;
+
+    const subject = emailNotif.name;
+    const publisher = await pubsub();
+    for (const user of users) {
+      const notification = new Notification({
+        action: subject,
+        content: { emailNotificationId: configId, subject, html },
+        user: user._id,
+        seenBy: [],
+      });
+      await notification.save();
+      publisher.publish(`user:${String(user._id)}`, { notification });
+    }
+  } catch (err) {
+    logger.error(
+      `Failed to create in-app notifications for email ${configId}: ${err.message}`,
+      { stack: err.stack }
+    );
+  }
+};
+
+/** Function names that actually send emails (not previews) */
+const EMAIL_SEND_FUNCTIONS = new Set([
+  'send-email',
+  'send-individual-email',
+  'send-quick-email',
+]);
+
+/**
  * Redirect POST request to Azure function
  */
 router.post('/:functionName/:configId?', async (req, res) => {
@@ -144,6 +207,12 @@ router.post('/:functionName/:configId?', async (req, res) => {
       requestConfig
     );
     res.status(200).send(response.data);
+
+    // Fire-and-forget: create in-app notifications for email recipients
+    if (configId && EMAIL_SEND_FUNCTIONS.has(functionName)) {
+      const html = typeof response.data === 'string' ? response.data : '';
+      createInAppNotificationsForEmailRecipients(configId, html);
+    }
   } catch (err) {
     logger.error(err.message, { stack: err.stack });
     res.status(500).send(req.t('common.errors.internalServerError'));
@@ -170,6 +239,12 @@ router.get('/:functionName/:configId?', async (req, res) => {
     );
 
     res.status(200).send(response.data);
+
+    // Fire-and-forget: create in-app notifications for GET-triggered email sends
+    if (configId && EMAIL_SEND_FUNCTIONS.has(functionName)) {
+      const html = typeof response.data === 'string' ? response.data : '';
+      createInAppNotificationsForEmailRecipients(configId, html);
+    }
   } catch (err) {
     logger.error(err.message, { stack: err.stack });
     res.status(500).send(req.t('common.errors.internalServerError'));

--- a/src/schema/mutation/addApplication.mutation.ts
+++ b/src/schema/mutation/addApplication.mutation.ts
@@ -1,7 +1,5 @@
 import { GraphQLError } from 'graphql';
-import channels from '@const/channels';
-import { Application, Role, Notification, Channel } from '@models';
-import pubsub from '../../server/pubsub';
+import { Application, Role, Channel } from '@models';
 import { ApplicationType } from '../types';
 import { AppAbility } from '@security/defineUserAbility';
 import { status } from '@const/enumTypes';
@@ -73,17 +71,6 @@ export default {
           };
         }
         await application.save();
-        // Send notification
-        const channel = await Channel.findOne({ title: channels.applications });
-        const notification = new Notification({
-          action: 'Application created',
-          content: application,
-          channel: channel.id,
-          seenBy: [],
-        });
-        await notification.save();
-        const publisher = await pubsub();
-        publisher.publish(channel.id, { notification });
         // Create main channel
         const mainChannel = new Channel({
           title: 'main',

--- a/src/schema/mutation/deleteApplication.mutation.ts
+++ b/src/schema/mutation/deleteApplication.mutation.ts
@@ -1,8 +1,6 @@
 import { GraphQLNonNull, GraphQLID, GraphQLError } from 'graphql';
 import { ApplicationType } from '../types';
-import { Application, Channel, Notification } from '@models';
-import pubsub from '../../server/pubsub';
-import channels from '@const/channels';
+import { Application } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { logger } from '@services/logger.service';
 import { accessibleBy } from '@casl/mongoose';
@@ -38,18 +36,6 @@ export default {
       const application = await Application.findOneAndDelete(filters);
       if (!application)
         throw new GraphQLError('common.errors.permissionNotGranted');
-      // Send notification
-      const channel = await Channel.findOne({ title: channels.applications });
-      const notification = new Notification({
-        action: 'Application deleted',
-        content: application,
-        //createdAt: new Date(),
-        channel: channel.id,
-        seenBy: [],
-      });
-      await notification.save();
-      const publisher = await pubsub();
-      publisher.publish(channel.id, { notification });
       return application;
     } catch (err) {
       logger.error(err.message, { stack: err.stack });

--- a/src/schema/query/notifications.query.ts
+++ b/src/schema/query/notifications.query.ts
@@ -42,6 +42,7 @@ export default {
       const abilityFilters = Notification.find(
         accessibleBy(ability, 'read').Notification
       ).getFilter();
+      // abilityFilters is already an $or combining channel-based and user-based rules
       const filters: any[] = [abilityFilters];
 
       const afterCursor = args.afterCursor;

--- a/src/schema/subscription/notification.subscription.ts
+++ b/src/schema/subscription/notification.subscription.ts
@@ -11,11 +11,14 @@ import { Context } from '@server/apollo/context';
 export default {
   type: NotificationType,
   subscribe: async (parent, args, context: Context) => {
-    // Subscribe to channels available in user's roles
     const subscriber: RedisPubSub = await pubsub();
     const user: User = context.user;
-    return subscriber.asyncIterator(
-      user.roles.map((role) => role.channels.map((x) => String(x._id))).flat()
-    );
+    const channelIds = user.roles
+      .map((role) => role.channels.map((x) => String(x._id)))
+      .flat();
+    return subscriber.asyncIterator([
+      ...channelIds,
+      `user:${String(user._id)}`,
+    ]);
   },
 };

--- a/src/schema/types/notification.type.ts
+++ b/src/schema/types/notification.type.ts
@@ -32,6 +32,13 @@ export const NotificationType = new GraphQLObjectType({
         return channel;
       },
     },
+    user: {
+      type: UserType,
+      async resolve(parent) {
+        if (!parent.user) return null;
+        return User.findById(parent.user);
+      },
+    },
     seenBy: {
       type: new GraphQLList(UserType),
       async resolve(parent, args, context) {

--- a/src/security/defineUserAbility.ts
+++ b/src/security/defineUserAbility.ts
@@ -340,6 +340,11 @@ export default function defineUserAbility(user: User | Client): AppAbility {
     },
     seenBy: { $ne: user._id },
   });
+  // User-targeted notifications (from email notifications)
+  can(['read', 'update'], 'Notification', {
+    user: user._id,
+    seenBy: { $ne: user._id },
+  });
 
   /* ===
     Creation / Access / Edition / Deletion of API configurations, PullJobs and ReferenceData


### PR DESCRIPTION
# Description

When an email notification is sent through the platform, recipient users who also have an account now receive the same notification as an in-app notification. The notification panel has been redesigned to support this, and useless system notifications (application created/deleted) have been removed.

## Useful links

- [Ticket AB#133554](https://dev.azure.com/who-ems/WHO-EMS/_workitems/edit/133554)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] UI test — seeded in-app notifications for a user and verified: notification badge appears, panel lists items with subject and timestamp, hover reveals individual mark-as-seen button, clicking a notification opens modal with rendered HTML, mark all as read clears the list, empty state displays when no notifications remain.



## Screenshots
[Screencast_20260626_032814.webm](https://github.com/user-attachments/assets/e030de43-b144-4795-98db-74a839c7dd56)


# Checklist:

- [ ] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules