### PR TITLE
AB#134566: ABC - Allow outdated files in file(s) fields

### DIFF
--- a/__tests__/unit-tests/utils/form/transformRecord.spec.ts
+++ b/__tests__/unit-tests/utils/form/transformRecord.spec.ts
@@ -1,73 +1,182 @@
+import { Types } from 'mongoose';
 import { formatValue, transformRecord } from '@utils/form/transformRecord';
 
 describe('formatValue', () => {
-  it('converts date-like fields to Date objects', () => {
-    for (const type of ['date', 'datetime', 'datetime-local']) {
-      const value = formatValue({ type }, '2023-05-15');
-      expect(value).toBeInstanceOf(Date);
-      expect(value.toISOString()).toBe(new Date('2023-05-15').toISOString());
-    }
-  });
-
-  it('joins text arrays into a string', () => {
-    expect(formatValue({ type: 'text' }, ['a', 'b'])).toBe('a,b');
-    expect(formatValue({ type: 'text' }, 'plain')).toBe('plain');
-  });
-
-  it('converts HH:mm time values to UTC dates', () => {
-    const value = formatValue({ type: 'time' }, '10:30');
-    expect(value).toBeInstanceOf(Date);
-    expect(value.toISOString()).toBe('1970-01-01T10:30:00.000Z');
-  });
-
-  // Documents current behavior: a Date value on a time field falls through
-  // the switch without returning, so the value is wiped to undefined
-  it('returns undefined for time fields already holding a Date', () => {
-    const date = new Date('1970-01-01T08:00:00.000Z');
-    expect(formatValue({ type: 'time' }, date)).toBeUndefined();
-  });
-
-  it('keeps only name and content for file fields', () => {
-    const files = [{ name: 'a.txt', content: 'abc', extra: true }];
-    expect(formatValue({ type: 'file' }, files)).toEqual([
-      { name: 'a.txt', content: 'abc' },
-    ]);
-  });
-
-  it('keeps valid resource ids and drops malformed 12-character ones', () => {
-    const validId = '507f1f77bcf86cd799439011';
-    expect(formatValue({ type: 'resource' }, validId)).toBe(validId);
-    // 12-character strings are a valid ObjectId input but do not round-trip
-    expect(formatValue({ type: 'resource' }, 'aaaaaaaaaaaa')).toBeNull();
-  });
-
-  it('filters invalid ids out of resources arrays', () => {
-    const validId = '507f1f77bcf86cd799439011';
-    expect(formatValue({ type: 'resources' }, [validId, 'aaaaaaaaaaaa'])).toEqual(
-      [validId]
+  describe('date fields', () => {
+    it.each(['date', 'datetime', 'datetime-local'])(
+      'converts a %s value to the beginning of the day',
+      (type) => {
+        const result = formatValue({ type }, '2024-05-15');
+        expect(result).toBeInstanceOf(Date);
+        expect(result.toISOString()).toBe(
+          new Date('2024-05-15').toISOString()
+        );
+      }
     );
+
+    it('leaves nil date values untouched', () => {
+      expect(formatValue({ type: 'date' }, null)).toBeUndefined();
+      expect(formatValue({ type: 'date' }, undefined)).toBeUndefined();
+    });
   });
 
-  it('returns unchanged values for unknown field types', () => {
-    expect(formatValue({ type: 'boolean' }, true)).toBe(true);
-    expect(formatValue({ type: 'numeric' }, 42)).toBe(42);
+  describe('text fields', () => {
+    it('returns strings as is', () => {
+      expect(formatValue({ type: 'text' }, 'hello')).toBe('hello');
+    });
+
+    it('joins array values into a comma-separated string', () => {
+      expect(formatValue({ type: 'text' }, ['a', 'b', 'c'])).toBe('a,b,c');
+    });
+
+    it('leaves nil text values untouched', () => {
+      expect(formatValue({ type: 'text' }, null)).toBeUndefined();
+    });
+  });
+
+  describe('time fields', () => {
+    it('converts a HH:mm string to a UTC date on the epoch day', () => {
+      const result = formatValue({ type: 'time' }, '10:30');
+      expect(result).toBeInstanceOf(Date);
+      expect(result.toISOString()).toBe('1970-01-01T10:30:00.000Z');
+    });
+
+    it('leaves nil time values untouched', () => {
+      expect(formatValue({ type: 'time' }, null)).toBeUndefined();
+    });
+  });
+
+  describe('file fields', () => {
+    it('keeps only the stored file properties', () => {
+      const files = [
+        {
+          name: 'report.pdf',
+          content: 'driveId',
+          size: 1234,
+          extraneous: true,
+        },
+      ];
+      expect(formatValue({ type: 'file' }, files)).toEqual([
+        { name: 'report.pdf', content: 'driveId' },
+      ]);
+    });
+
+    it('preserves the type property when set', () => {
+      const files = [
+        { name: 'report.pdf', content: 'driveId', type: 'application/pdf' },
+      ];
+      expect(formatValue({ type: 'file' }, files)).toEqual([
+        { name: 'report.pdf', content: 'driveId', type: 'application/pdf' },
+      ]);
+    });
+
+    it('preserves the outdated flag only when true', () => {
+      const files = [
+        { name: 'a.pdf', content: '1', outdated: true },
+        { name: 'b.pdf', content: '2', outdated: false },
+      ];
+      expect(formatValue({ type: 'file' }, files)).toEqual([
+        { name: 'a.pdf', content: '1', outdated: true },
+        { name: 'b.pdf', content: '2' },
+      ]);
+    });
+
+    it('leaves nil file values untouched', () => {
+      expect(formatValue({ type: 'file' }, null)).toBeUndefined();
+    });
+  });
+
+  describe('resource fields', () => {
+    it('returns a valid mongo id', () => {
+      const id = new Types.ObjectId().toHexString();
+      expect(formatValue({ type: 'resource' }, id)).toBe(id);
+    });
+
+    it('returns null for an invalid mongo id', () => {
+      expect(formatValue({ type: 'resource' }, 'aaaaaaaaaaaa')).toBeNull();
+    });
+
+    it('leaves nil resource values untouched', () => {
+      expect(formatValue({ type: 'resource' }, null)).toBeUndefined();
+    });
+  });
+
+  describe('resources fields', () => {
+    it('keeps only valid mongo ids', () => {
+      const validId = new Types.ObjectId().toHexString();
+      expect(
+        formatValue({ type: 'resources' }, [validId, 'aaaaaaaaaaaa'])
+      ).toEqual([validId]);
+    });
+
+    it('leaves non-array resources values untouched', () => {
+      expect(formatValue({ type: 'resources' }, 'not-an-array')).toBeUndefined();
+      expect(formatValue({ type: 'resources' }, null)).toBeUndefined();
+    });
+  });
+
+  describe('people fields', () => {
+    it('returns people-dropdown values as is', () => {
+      expect(formatValue({ type: 'people-dropdown' }, 'user-1')).toBe(
+        'user-1'
+      );
+      expect(formatValue({ type: 'people-dropdown' }, null)).toBeUndefined();
+    });
+
+    it('returns people-tagbox arrays as is', () => {
+      expect(
+        formatValue({ type: 'people-tagbox' }, ['user-1', 'user-2'])
+      ).toEqual(['user-1', 'user-2']);
+    });
+
+    it('leaves non-array people-tagbox values untouched', () => {
+      expect(
+        formatValue({ type: 'people-tagbox' }, 'not-an-array')
+      ).toBeUndefined();
+    });
+  });
+
+  describe('other field types', () => {
+    it('returns the value as is, even when nil', () => {
+      expect(formatValue({ type: 'boolean' }, true)).toBe(true);
+      expect(formatValue({ type: 'numeric' }, 42)).toBe(42);
+      expect(formatValue({ type: 'checkbox' }, null)).toBeNull();
+    });
   });
 });
 
 describe('transformRecord', () => {
-  it('formats known fields and removes unknown ones', () => {
-    const record: any = {
-      startDate: '2023-05-15',
-      tags: ['a', 'b'],
-      ghost: 'should be removed',
+  const fields = [
+    { name: 'title', type: 'text' },
+    { name: 'dueDate', type: 'date' },
+    { name: 'active', type: 'boolean' },
+  ];
+
+  it('formats each value according to its field definition', async () => {
+    const record = {
+      title: ['a', 'b'],
+      dueDate: '2024-05-15',
+      active: true,
     };
-    const fields = [
-      { name: 'startDate', type: 'date' },
-      { name: 'tags', type: 'text' },
-    ];
-    const transformed: any = transformRecord(record, fields);
-    expect(transformed.startDate).toBeInstanceOf(Date);
-    expect(transformed.tags).toBe('a,b');
-    expect(transformed).not.toHaveProperty('ghost');
+    const result = await transformRecord(record, fields);
+    expect(result.title).toBe('a,b');
+    expect(result.dueDate).toBeInstanceOf(Date);
+    expect(result.active).toBe(true);
+  });
+
+  it('removes values that do not match any field', async () => {
+    const record = { title: 'hello', unknownField: 'value' };
+    const result = await transformRecord(record, fields);
+    expect(result).not.toHaveProperty('unknownField');
+    expect(result.title).toBe('hello');
+  });
+
+  it('mutates and returns the same record object', async () => {
+    const record = { title: 'hello' };
+    expect(await transformRecord(record, fields)).toBe(record);
+  });
+
+  it('returns an empty record unchanged', async () => {
+    expect(await transformRecord({}, fields)).toEqual({});
   });
 });

--- a/src/models/resource.model.ts
+++ b/src/models/resource.model.ts
@@ -29,6 +29,7 @@ export interface Resource extends Document {
     permissions?: {
       canSee: any[];
       canUpdate: any[];
+      canDeleteFiles?: any[];
     };
     [key: string]: any;
   }[];

--- a/src/schema/mutation/editResource.mutation.ts
+++ b/src/schema/mutation/editResource.mutation.ts
@@ -55,6 +55,7 @@ type SimpleFieldPermissionChange = {
 type FieldPermissionChange = {
   canSee?: SimpleFieldPermissionChange;
   canUpdate?: SimpleFieldPermissionChange;
+  canDeleteFiles?: SimpleFieldPermissionChange;
 };
 
 /** Type for the calculated field argument */
@@ -89,6 +90,7 @@ const addFieldPermission = (
       [`fields.${fieldIndex}.permissions`]: {
         canSee: [],
         canUpdate: [],
+        canDeleteFiles: [],
       },
     };
     if (update.$set) Object.assign(update.$set, newPermission);
@@ -146,7 +148,8 @@ const checkFieldPermission = (
       }
       break;
     }
-    case 'canUpdate': {
+    case 'canUpdate':
+    case 'canDeleteFiles': {
       if (
         !get(resourcePermissions, resourcePermission.CREATE_RECORDS, []).find(
           (p) => p.role.equals(role)

--- a/src/schema/types/metadata.type.ts
+++ b/src/schema/types/metadata.type.ts
@@ -54,6 +54,18 @@ export const FieldMetaDataType = new GraphQLObjectType({
         }
       },
     },
+    canDeleteFiles: {
+      type: GraphQLBoolean,
+      resolve: (parent, _, context) => {
+        const ability: AppAbility = context.user._abilityForRecords;
+        const ogParent: Form | Resource = context._parent;
+        if (selectableDefaultRecordFieldsFlat.includes(parent.name)) {
+          return false;
+        } else {
+          return ability.can('deleteFiles', ogParent, `data.${parent.name}`);
+        }
+      },
+    },
     options: {
       type: GraphQLJSON,
       resolve: async (parent, _, context) => {

--- a/src/security/defineUserAbility.ts
+++ b/src/security/defineUserAbility.ts
@@ -57,7 +57,10 @@ export type Actions =
   // application specific
   | 'manageUsers'
   | 'download'
-  | 'upload';
+  | 'upload'
+  // allowed to delete already-persisted files on a field (as opposed to
+  // only flagging them as outdated), see the "outdated files" file field option
+  | 'deleteFiles';
 
 /** Define subjects types for casl */
 type Models =

--- a/src/security/extendAbilityForRecords.ts
+++ b/src/security/extendAbilityForRecords.ts
@@ -28,15 +28,21 @@ const appAbility = Ability as AbilityClass<AppAbility>;
  * @returns A boolean indicating if the user has the permission
  */
 function userCanAccessField(
-  type: 'read' | 'update',
+  type: 'read' | 'update' | 'deleteFiles',
   user: User,
   field: any
 ): boolean {
   if (field === undefined) return false;
-  const arrayToCheck = type === 'read' ? 'canSee' : 'canUpdate';
+  const arrayToCheck =
+    type === 'read'
+      ? 'canSee'
+      : type === 'deleteFiles'
+      ? 'canDeleteFiles'
+      : 'canUpdate';
 
   // If the readOnly property of the field is true, ignore the permission check to update the records
-  if (arrayToCheck === 'canUpdate') {
+  // (also applies to deleting files: a read-only field cannot be modified at all)
+  if (arrayToCheck === 'canUpdate' || arrayToCheck === 'canDeleteFiles') {
     if (field.readOnly) {
       return false;
     }
@@ -83,7 +89,7 @@ export function userHasRoleFor(
  * @returns list of accessible fields for type
  */
 function getAccessibleFields(
-  type: 'read' | 'update',
+  type: 'read' | 'update' | 'deleteFiles',
   user: User,
   resource: Resource
 ): string[] {
@@ -158,6 +164,13 @@ function extendAbilityForRecordsOnForm(
     // Get all accessible fields
     const readableFields = getAccessibleFields('read', user, resource);
     const editableFields = getAccessibleFields('update', user, resource);
+    // Fields (file questions) on which the user is allowed to delete files
+    // outright, rather than only flag them as outdated
+    const fileDeletableFields = getAccessibleFields(
+      'deleteFiles',
+      user,
+      resource
+    );
 
     // create a new record
     if (userHasRoleFor(resourcePermission.CREATE_RECORDS, user, resource)) {
@@ -236,6 +249,14 @@ function extendAbilityForRecordsOnForm(
     if (editableFields.length > 0) {
       can('update', 'Resource', editableFields, { _id: resource._id });
       can('update', 'Form', editableFields, { _id: form._id });
+    }
+    // Fields on which the user can delete already-persisted files (as
+    // opposed to only flagging them as outdated)
+    if (fileDeletableFields.length > 0) {
+      can('deleteFiles', 'Resource', fileDeletableFields, {
+        _id: resource._id,
+      });
+      can('deleteFiles', 'Form', fileDeletableFields, { _id: form._id });
     }
 
     // return the new ability instance

--- a/src/utils/form/metadata.helper.ts
+++ b/src/utils/form/metadata.helper.ts
@@ -13,6 +13,7 @@ export type Metadata = {
   filter?: { defaultOperator?: string; operators: string[] };
   canSee?: boolean;
   canUpdate?: boolean;
+  canDeleteFiles?: boolean;
   multiSelect?: boolean;
   filterable?: boolean;
   options?: { text: string; value: any }[];

--- a/src/utils/form/transformRecord.ts
+++ b/src/utils/form/transformRecord.ts
@@ -3,6 +3,27 @@ import { getDateForMongo } from '../filter/getDateForMongo';
 import { getTimeForMongo } from '../filter/getTimeForMongo';
 import isNil from 'lodash/isNil';
 
+/** Stored file field value. */
+type FileValue = {
+  name: string;
+  content: unknown;
+  type?: string;
+  outdated?: boolean;
+};
+
+/**
+ * Formats file metadata for storage while preserving display/status fields.
+ *
+ * @param file File value
+ * @returns Stored file value
+ */
+const formatFileValue = (file: FileValue): FileValue => ({
+  name: file.name,
+  content: file.content,
+  ...(file.type && { type: file.type }),
+  ...(file.outdated === true && { outdated: true }),
+});
+
 /**
  * Format passed value to comply with field definition.
  *
@@ -40,7 +61,7 @@ export const formatValue = (field: any, value: any): any => {
       break;
     case 'file':
       if (!isNil(value)) {
-        return value.map((x) => ({ name: x.name, content: x.content }));
+        return value.map(formatFileValue);
       }
       break;
     case 'resource':


### PR DESCRIPTION
# Description

Adds configurable outdated-file handling for file upload fields.

This change allows form builders to enable a field-level option for file upload questions so existing files cannot be removed, but can instead be marked as outdated or restored. The behavior applies to both single-file and multi-file fields. Outdated files remain attached to the record and continue to count toward upload limits.

It also adds display controls for outdated files in HTML questions and grid/layout fields, so each widget/layout can decide whether outdated files should be visible. Outdated files are visually marked with a warning icon wherever they are displayed.

Fixes: [AB#134566](https://dev.azure.com/WHOHQ/2888b816-2d79-49ef-a86e-561e6cd456a0/_workitems/edit/134566) - ABC - Allow outdated files in file(s) fields

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/134566/

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

The following checks were run locally:

- [x] Frontend lint: `npx nx lint shared`
- [x] Frontend tests: `npx nx test shared --runInBand`
- [x] Backend lint: `npm run lint`
- [x] Backend build: `npm run build`

Manual verification performed:

- Enabled `Allow marking files as outdated` on single-file and multi-file upload fields.
- Verified existing files cannot be removed when the option is enabled.
- Verified files can be marked as outdated and restored.
- Verified outdated status persists after saving and reopening a record.
- Verified single-file upload limits are respected.
- Verified multi-file upload limits are respected.
- Verified outdated files are marked with a warning icon in record edit mode, detail mode, HTML questions, and grids.
- Verified `Show outdated files` can hide outdated files in HTML questions.
- Verified `Show outdated files` can hide outdated files in grid layout fields.

## Screenshots

Single and multi-file fields now have the options to mark files as outdated:

<img width="1919" height="665" alt="image" src="https://github.com/user-attachments/assets/c47f5da6-ee83-4b5f-b25d-e5504e142254" />

Adding the mark to any file:

<img width="1245" height="617" alt="image" src="https://github.com/user-attachments/assets/f3561bd6-70be-4c24-abfe-f60589ebd67a" />

<img width="1742" height="1139" alt="image" src="https://github.com/user-attachments/assets/0bf8e2a7-c9fb-4893-ae4a-0b11ac4375cc" />

These fields can be referenced on HTML fields and Grids. Configuration allows for them to show (or not) the outdated files.

<img width="2093" height="818" alt="image" src="https://github.com/user-attachments/assets/ec1dd504-19ad-48eb-be12-43373593eb6b" />

<img width="1172" height="997" alt="image" src="https://github.com/user-attachments/assets/13009982-6744-4e64-bcda-4ee711df9140" />

How outdated files are shown in Grids and HTML fields:

<img width="2117" height="883" alt="image" src="https://github.com/user-attachments/assets/4f03b244-fa5f-462f-a7bf-e375a990949d" />

Outdated files on view mode:

<img width="1936" height="658" alt="image" src="https://github.com/user-attachments/assets/26a9d026-0fed-41c8-81d6-a8d5e61b2d92" />

When the Show Outdated Files toggle is off:

<img width="2494" height="1030" alt="image" src="https://github.com/user-attachments/assets/e29f82fb-5fd2-413b-8d14-16650354003a" />

<img width="1871" height="649" alt="image" src="https://github.com/user-attachments/assets/0a3eae65-8e8e-4034-be0e-0590ed78813c" />

# Checklist:

( * == Mandatory )

- [ ] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules