### PR TITLE
feat: Enhance record history performance with pagination support and …

### DIFF
--- a/__tests__/unit-tests/schema/query/recordHistory.query.spec.ts
+++ b/__tests__/unit-tests/schema/query/recordHistory.query.spec.ts
@@ -100,21 +100,48 @@ describe('RecordHistory Query Resolver', () => {
     );
   });
 
-  it('should fetch history with page and limit parameters if page or limit is provided', async () => {
-    const args = { id: 'recordId', page: 2, limit: 10 };
+  it('should fetch history with pagination, fields and date range parameters', async () => {
+    const fromDate = new Date('2026-07-01T00:00:00Z');
+    const toDate = new Date('2026-07-05T00:00:00Z');
+    const args = {
+      id: 'recordId',
+      first: 10,
+      skip: 20,
+      fields: ['name'],
+      fromDate,
+      toDate,
+    };
     const result = await resolver.resolve(null, args, context);
 
     expect(RecordHistory).toHaveBeenCalledWith(mockRecord, expect.any(Object));
-    expect(mockGetHistory).toHaveBeenCalledWith({ page: 2, limit: 10 });
+    expect(mockGetHistory).toHaveBeenCalledWith({
+      skip: 20,
+      limit: 10,
+      fields: ['name'],
+      fromDate,
+      toDate,
+    });
     expect(result).toBeDefined();
   });
 
-  it('should fetch history without pagination if no page or limit is provided', async () => {
+  it('should fetch history without pagination if no first or skip is provided', async () => {
     const args = { id: 'recordId' };
     const result = await resolver.resolve(null, args, context);
 
     expect(RecordHistory).toHaveBeenCalledWith(mockRecord, expect.any(Object));
-    expect(mockGetHistory).toHaveBeenCalledWith(undefined);
+    expect(mockGetHistory).toHaveBeenCalledWith({
+      skip: undefined,
+      limit: undefined,
+      fields: undefined,
+    });
     expect(result).toBeDefined();
+  });
+
+  it('should throw an error if the requested page size is too large', async () => {
+    const args = { id: 'recordId', first: 5000 };
+    await expect(resolver.resolve(null, args, context)).rejects.toThrow(
+      GraphQLError
+    );
+    expect(mockGetHistory).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/unit-tests/schema/query/recordHistory.query.spec.ts
+++ b/__tests__/unit-tests/schema/query/recordHistory.query.spec.ts
@@ -1,0 +1,120 @@
+import { Record, Form } from '@models';
+import extendAbilityForRecords from '@security/extendAbilityForRecords';
+import { graphQLAuthCheck } from '@schema/shared';
+import { RecordHistory } from '@utils/history';
+import resolver from '@schema/query/recordHistory.query';
+import { GraphQLError } from 'graphql';
+
+jest.mock('@models', () => {
+  const mockRecordFindById = jest.fn();
+  const mockFormFindById = jest.fn();
+  const mockVersionFind = jest.fn();
+  return {
+    Record: {
+      findById: mockRecordFindById,
+    },
+    Form: {
+      findById: mockFormFindById,
+    },
+    Version: {
+      find: mockVersionFind,
+    },
+  };
+});
+jest.mock('@security/extendAbilityForRecords');
+jest.mock('@schema/shared');
+jest.mock('@utils/history');
+jest.mock('@services/logger.service');
+
+describe('RecordHistory Query Resolver', () => {
+  let context: any;
+  let mockRecord: any;
+  let mockForm: any;
+  let mockGetHistory: any;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    
+    context = {
+      i18next: {
+        t: jest.fn().mockImplementation((key) => key),
+        i18n: {
+          changeLanguage: jest.fn(),
+          t: jest.fn().mockImplementation((key) => key),
+        },
+      },
+      user: { id: 'userId' } as any,
+    };
+
+    mockRecord = { id: 'recordId', form: 'formId', versions: [] };
+    mockForm = { id: 'formId' };
+    mockGetHistory = jest.fn().mockResolvedValue([
+      { changes: [{ type: 'add', field: 'name', old: null, new: 'value' }] },
+    ]);
+
+    (graphQLAuthCheck as jest.Mock).mockImplementation(() => {});
+    
+    (Record.findById as jest.Mock).mockImplementation(() => ({
+      populate: jest.fn().mockResolvedValue(mockRecord),
+    }));
+
+    (Form.findById as jest.Mock).mockResolvedValue(mockForm);
+
+    (extendAbilityForRecords as jest.Mock).mockResolvedValue({
+      cannot: jest.fn().mockReturnValue(false),
+    });
+
+    (RecordHistory as any).mockImplementation(() => {
+      return { getHistory: mockGetHistory };
+    });
+  });
+
+  it('should throw error if record is not found', async () => {
+    (Record.findById as jest.Mock).mockImplementation(() => ({
+      populate: jest.fn().mockResolvedValue(null),
+    }));
+
+    const args = { id: 'recordId' };
+    await expect(resolver.resolve(null, args, context)).rejects.toThrow(
+      'common.errors.permissionNotGranted'
+    );
+  });
+
+  it('should throw error if form is not found', async () => {
+    (Form.findById as jest.Mock).mockResolvedValue(null);
+
+    const args = { id: 'recordId' };
+    await expect(resolver.resolve(null, args, context)).rejects.toThrow(
+      'common.errors.permissionNotGranted'
+    );
+  });
+
+  it('should throw error if user has no read permission', async () => {
+    (extendAbilityForRecords as jest.Mock).mockResolvedValue({
+      cannot: jest.fn().mockReturnValue(true),
+    });
+
+    const args = { id: 'recordId' };
+    await expect(resolver.resolve(null, args, context)).rejects.toThrow(
+      'common.errors.permissionNotGranted'
+    );
+  });
+
+  it('should fetch history with page and limit parameters if page or limit is provided', async () => {
+    const args = { id: 'recordId', page: 2, limit: 10 };
+    const result = await resolver.resolve(null, args, context);
+
+    expect(RecordHistory).toHaveBeenCalledWith(mockRecord, expect.any(Object));
+    expect(mockGetHistory).toHaveBeenCalledWith({ page: 2, limit: 10 });
+    expect(result).toBeDefined();
+  });
+
+  it('should fetch history without pagination if no page or limit is provided', async () => {
+    const args = { id: 'recordId' };
+    const result = await resolver.resolve(null, args, context);
+
+    expect(RecordHistory).toHaveBeenCalledWith(mockRecord, expect.any(Object));
+    expect(mockGetHistory).toHaveBeenCalledWith(undefined);
+    expect(result).toBeDefined();
+  });
+});

--- a/__tests__/unit-tests/utils/history/recordHistory.spec.ts
+++ b/__tests__/unit-tests/utils/history/recordHistory.spec.ts
@@ -1,0 +1,164 @@
+import { RecordHistory } from '@utils/history';
+import { Record, Version } from '@models';
+
+jest.mock('@models');
+
+describe('RecordHistory Class Unit Tests', () => {
+  let record: any;
+  let options: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    record = {
+      createdAt: new Date('2026-07-01T12:00:00Z'),
+      modifiedAt: new Date('2026-07-04T12:00:00Z'),
+      _createdBy: { user: { name: 'Creator User' } },
+      versions: ['versionId1', 'versionId2', 'versionId3'],
+      resource: {
+        fields: [
+          { name: 'name', title: 'Name Field' },
+          { name: 'age', title: 'Age Field' },
+        ],
+      },
+      form: {
+        structure: JSON.stringify({
+          pages: [
+            {
+              elements: [
+                { type: 'text', name: 'name', title: 'Name Field' },
+                { type: 'text', name: 'age', title: 'Age Field' },
+              ],
+            },
+          ],
+        }),
+      },
+      data: { name: 'Alice', age: 30 },
+      accessibleFieldsBy: jest.fn().mockReturnValue(['data']),
+      model: jest.fn().mockReturnValue(Version),
+    };
+
+    options = {
+      translate: jest.fn().mockImplementation((key) => key),
+      ability: {} as any,
+      context: {
+        locale: 'en',
+      },
+    };
+  });
+
+  it('should instantiate and extract fields correctly', () => {
+    const recordHistory = new RecordHistory(record, options);
+    expect(recordHistory.fields).toBeDefined();
+    expect(recordHistory.fields.length).toBe(2);
+  });
+
+  it('should process history without pagination correctly', async () => {
+    const versionsList = [
+      {
+        _id: 'versionId1',
+        createdAt: new Date('2026-07-02T12:00:00Z'),
+        data: { name: 'Bob', age: 25 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId1', createdAt: new Date('2026-07-02T12:00:00Z'), data: { name: 'Bob', age: 25 } }),
+      },
+      {
+        _id: 'versionId2',
+        createdAt: new Date('2026-07-03T12:00:00Z'),
+        data: { name: 'Bob', age: 28 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId2', createdAt: new Date('2026-07-03T12:00:00Z'), data: { name: 'Bob', age: 28 } }),
+      },
+      {
+        _id: 'versionId3',
+        createdAt: new Date('2026-07-04T12:00:00Z'),
+        data: { name: 'Alice', age: 28 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId3', createdAt: new Date('2026-07-04T12:00:00Z'), data: { name: 'Alice', age: 28 } }),
+      },
+    ];
+
+    (Version.find as jest.Mock).mockReturnValue({
+      populate: jest.fn().mockResolvedValue(versionsList),
+    });
+
+    const recordHistory = new RecordHistory(record, options);
+    const history = await recordHistory.getHistory();
+
+    expect(history.length).toBe(4); // initial + v1 + v2 + current
+    expect(history[0].changes.length).toBe(1); // current vs v3: age changed from 28 to 30
+    expect(history[0].changes[0].old).toBe(28);
+    expect(history[0].changes[0].new).toBe(30);
+  });
+
+  it('should process history with page=1, limit=2 correctly', async () => {
+    const versionsList = [
+      {
+        _id: 'versionId2',
+        createdAt: new Date('2026-07-03T12:00:00Z'),
+        data: { name: 'Bob', age: 28 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId2', createdAt: new Date('2026-07-03T12:00:00Z'), data: { name: 'Bob', age: 28 } }),
+      },
+      {
+        _id: 'versionId3',
+        createdAt: new Date('2026-07-04T12:00:00Z'),
+        data: { name: 'Alice', age: 28 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId3', createdAt: new Date('2026-07-04T12:00:00Z'), data: { name: 'Alice', age: 28 } }),
+      },
+    ];
+
+    (Version.find as jest.Mock).mockReturnValue({
+      populate: jest.fn().mockResolvedValue(versionsList),
+    });
+
+    const recordHistory = new RecordHistory(record, options);
+    // page 1, limit 2: entries index 0 and 1 (current vs v3, v3 vs v2)
+    // Needs versions: N-1 = 2 (v3), N-2 = 1 (v2), N-3 = 0 (v1) for boundary.
+    // Clamped slice: versions index 1 and 2 (v2 and v3) since skip=0, endEntry=1.
+    const history = await recordHistory.getHistory({ page: 1, limit: 2 });
+
+    expect(Version.find).toHaveBeenCalledWith({
+      _id: { $in: ['versionId2', 'versionId3'] },
+    });
+    expect(history.length).toBe(2);
+    expect(history[0].changes[0].field).toBe('age'); // age modified from 28 to 30
+    expect(history[1].changes[0].field).toBe('name'); // name modified from Bob to Alice
+  });
+
+  it('should return an empty array when the requested page is past the end of history', async () => {
+    const recordHistory = new RecordHistory(record, options);
+    // record has 3 versions -> 4 total entries (reversed indices 0..3), so a
+    // page starting at index 4 has nothing to return.
+    const history = await recordHistory.getHistory({ page: 3, limit: 2 });
+
+    expect(Version.find).not.toHaveBeenCalled();
+    expect(history).toEqual([]);
+  });
+
+  it('should apply pagination to a record with no prior versions', async () => {
+    const noVersionsRecord = { ...record, versions: [] };
+    const recordHistory = new RecordHistory(noVersionsRecord, options);
+
+    const firstPage = await recordHistory.getHistory({ page: 1, limit: 1 });
+    expect(Version.find).not.toHaveBeenCalled();
+    expect(firstPage.length).toBe(1);
+
+    const secondPage = await recordHistory.getHistory({ page: 2, limit: 1 });
+    expect(secondPage).toEqual([]);
+  });
+
+  it('should leave a boolean value unchanged when no label is configured', async () => {
+    const booleanRecord = {
+      ...record,
+      versions: [],
+      resource: {
+        fields: [{ name: 'active', title: 'Active Field', type: 'boolean' }],
+      },
+      data: { active: true },
+    };
+    const recordHistory = new RecordHistory(booleanRecord, options);
+
+    const history = await recordHistory.getHistory();
+
+    expect(history.length).toBe(1);
+    expect(history[0].changes[0].field).toBe('active');
+    expect(history[0].changes[0].new).toBe(true);
+  });
+});

--- a/__tests__/unit-tests/utils/history/recordHistory.spec.ts
+++ b/__tests__/unit-tests/utils/history/recordHistory.spec.ts
@@ -88,7 +88,7 @@ describe('RecordHistory Class Unit Tests', () => {
     expect(history[0].changes[0].new).toBe(30);
   });
 
-  it('should process history with page=1, limit=2 correctly', async () => {
+  it('should process history with skip=0, limit=2 correctly', async () => {
     const versionsList = [
       {
         _id: 'versionId2',
@@ -109,10 +109,10 @@ describe('RecordHistory Class Unit Tests', () => {
     });
 
     const recordHistory = new RecordHistory(record, options);
-    // page 1, limit 2: entries index 0 and 1 (current vs v3, v3 vs v2)
+    // skip 0, limit 2: entries index 0 and 1 (current vs v3, v3 vs v2)
     // Needs versions: N-1 = 2 (v3), N-2 = 1 (v2), N-3 = 0 (v1) for boundary.
     // Clamped slice: versions index 1 and 2 (v2 and v3) since skip=0, endEntry=1.
-    const history = await recordHistory.getHistory({ page: 1, limit: 2 });
+    const history = await recordHistory.getHistory({ skip: 0, limit: 2 });
 
     expect(Version.find).toHaveBeenCalledWith({
       _id: { $in: ['versionId2', 'versionId3'] },
@@ -126,7 +126,7 @@ describe('RecordHistory Class Unit Tests', () => {
     const recordHistory = new RecordHistory(record, options);
     // record has 3 versions -> 4 total entries (reversed indices 0..3), so a
     // page starting at index 4 has nothing to return.
-    const history = await recordHistory.getHistory({ page: 3, limit: 2 });
+    const history = await recordHistory.getHistory({ skip: 4, limit: 2 });
 
     expect(Version.find).not.toHaveBeenCalled();
     expect(history).toEqual([]);
@@ -136,11 +136,11 @@ describe('RecordHistory Class Unit Tests', () => {
     const noVersionsRecord = { ...record, versions: [] };
     const recordHistory = new RecordHistory(noVersionsRecord, options);
 
-    const firstPage = await recordHistory.getHistory({ page: 1, limit: 1 });
+    const firstPage = await recordHistory.getHistory({ skip: 0, limit: 1 });
     expect(Version.find).not.toHaveBeenCalled();
     expect(firstPage.length).toBe(1);
 
-    const secondPage = await recordHistory.getHistory({ page: 2, limit: 1 });
+    const secondPage = await recordHistory.getHistory({ skip: 1, limit: 1 });
     expect(secondPage).toEqual([]);
   });
 

--- a/__tests__/unit-tests/utils/history/recordHistory.spec.ts
+++ b/__tests__/unit-tests/utils/history/recordHistory.spec.ts
@@ -236,6 +236,45 @@ describe('RecordHistory Class Unit Tests', () => {
     expect(history[2].changes[0].new).toBe(25); // creation
   });
 
+  it('should only return entries within the given date range', async () => {
+    const versionsList = [
+      {
+        _id: 'versionId1',
+        createdAt: new Date('2026-07-02T12:00:00Z'),
+        data: { name: 'Bob', age: 25 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId1', createdAt: new Date('2026-07-02T12:00:00Z'), data: { name: 'Bob', age: 25 } }),
+      },
+      {
+        _id: 'versionId2',
+        createdAt: new Date('2026-07-03T12:00:00Z'),
+        data: { name: 'Bob', age: 28 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId2', createdAt: new Date('2026-07-03T12:00:00Z'), data: { name: 'Bob', age: 28 } }),
+      },
+      {
+        _id: 'versionId3',
+        createdAt: new Date('2026-07-04T12:00:00Z'),
+        data: { name: 'Alice', age: 28 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId3', createdAt: new Date('2026-07-04T12:00:00Z'), data: { name: 'Alice', age: 28 } }),
+      },
+    ];
+
+    (Version.find as jest.Mock).mockReturnValue({
+      populate: jest.fn().mockResolvedValue(versionsList),
+    });
+
+    const recordHistory = new RecordHistory(record, options);
+    const history = await recordHistory.getHistory({
+      fromDate: new Date('2026-07-03T00:00:00Z'),
+      toDate: new Date('2026-07-03T23:59:59Z'),
+    });
+
+    // Only the v1 -> v2 entry (created 2026-07-03) is in range
+    expect(history.length).toBe(1);
+    expect(history[0].changes[0].field).toBe('age');
+    expect(history[0].changes[0].old).toBe(25);
+    expect(history[0].changes[0].new).toBe(28);
+  });
+
   it('should apply pagination to a record with no prior versions', async () => {
     const noVersionsRecord = { ...record, versions: [] };
     const recordHistory = new RecordHistory(noVersionsRecord, options);

--- a/__tests__/unit-tests/utils/history/recordHistory.spec.ts
+++ b/__tests__/unit-tests/utils/history/recordHistory.spec.ts
@@ -123,13 +123,117 @@ describe('RecordHistory Class Unit Tests', () => {
   });
 
   it('should return an empty array when the requested page is past the end of history', async () => {
+    const versionsList = [
+      {
+        _id: 'versionId1',
+        createdAt: new Date('2026-07-02T12:00:00Z'),
+        data: { name: 'Bob', age: 25 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId1', createdAt: new Date('2026-07-02T12:00:00Z'), data: { name: 'Bob', age: 25 } }),
+      },
+      {
+        _id: 'versionId2',
+        createdAt: new Date('2026-07-03T12:00:00Z'),
+        data: { name: 'Bob', age: 28 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId2', createdAt: new Date('2026-07-03T12:00:00Z'), data: { name: 'Bob', age: 28 } }),
+      },
+      {
+        _id: 'versionId3',
+        createdAt: new Date('2026-07-04T12:00:00Z'),
+        data: { name: 'Alice', age: 28 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId3', createdAt: new Date('2026-07-04T12:00:00Z'), data: { name: 'Alice', age: 28 } }),
+      },
+    ];
+
+    (Version.find as jest.Mock).mockReturnValue({
+      populate: jest.fn().mockResolvedValue(versionsList),
+    });
+
     const recordHistory = new RecordHistory(record, options);
-    // record has 3 versions -> 4 total entries (reversed indices 0..3), so a
-    // page starting at index 4 has nothing to return.
+    // record has 3 versions -> 4 total entries, all with changes, so skipping
+    // 4 displayable entries leaves nothing to return.
     const history = await recordHistory.getHistory({ skip: 4, limit: 2 });
 
-    expect(Version.find).not.toHaveBeenCalled();
     expect(history).toEqual([]);
+  });
+
+  it('should not count entries with empty changes towards pagination', async () => {
+    // v3 has the same data as v2, so the v2 -> v3 entry has no changes and
+    // must be skipped: the page is filled with the next non-empty entry.
+    const versionsList = [
+      {
+        _id: 'versionId1',
+        createdAt: new Date('2026-07-02T12:00:00Z'),
+        data: { name: 'Bob', age: 25 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId1', createdAt: new Date('2026-07-02T12:00:00Z'), data: { name: 'Bob', age: 25 } }),
+      },
+      {
+        _id: 'versionId2',
+        createdAt: new Date('2026-07-03T12:00:00Z'),
+        data: { name: 'Bob', age: 28 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId2', createdAt: new Date('2026-07-03T12:00:00Z'), data: { name: 'Bob', age: 28 } }),
+      },
+      {
+        _id: 'versionId3',
+        createdAt: new Date('2026-07-04T12:00:00Z'),
+        data: { name: 'Bob', age: 28 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId3', createdAt: new Date('2026-07-04T12:00:00Z'), data: { name: 'Bob', age: 28 } }),
+      },
+    ];
+    record.data = { name: 'Alice', age: 28 };
+
+    (Version.find as jest.Mock).mockReturnValue({
+      populate: jest.fn().mockResolvedValue(versionsList),
+    });
+
+    const recordHistory = new RecordHistory(record, options);
+    const history = await recordHistory.getHistory({ skip: 0, limit: 2 });
+
+    expect(history.length).toBe(2);
+    expect(history[0].changes[0].field).toBe('name'); // current vs v3
+    expect(history[1].changes[0].field).toBe('age'); // v1 vs v2, empty v2 vs v3 skipped
+  });
+
+  it('should only return changes on the given fields', async () => {
+    const versionsList = [
+      {
+        _id: 'versionId1',
+        createdAt: new Date('2026-07-02T12:00:00Z'),
+        data: { name: 'Bob', age: 25 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId1', createdAt: new Date('2026-07-02T12:00:00Z'), data: { name: 'Bob', age: 25 } }),
+      },
+      {
+        _id: 'versionId2',
+        createdAt: new Date('2026-07-03T12:00:00Z'),
+        data: { name: 'Bob', age: 28 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId2', createdAt: new Date('2026-07-03T12:00:00Z'), data: { name: 'Bob', age: 28 } }),
+      },
+      {
+        _id: 'versionId3',
+        createdAt: new Date('2026-07-04T12:00:00Z'),
+        data: { name: 'Alice', age: 28 },
+        toObject: jest.fn().mockReturnValue({ _id: 'versionId3', createdAt: new Date('2026-07-04T12:00:00Z'), data: { name: 'Alice', age: 28 } }),
+      },
+    ];
+
+    (Version.find as jest.Mock).mockReturnValue({
+      populate: jest.fn().mockResolvedValue(versionsList),
+    });
+
+    const recordHistory = new RecordHistory(record, options);
+    const history = await recordHistory.getHistory({ fields: ['age'] });
+
+    // v2 -> v3 only changes 'name', so it is dropped entirely
+    expect(history.length).toBe(3);
+    for (const entry of history) {
+      expect(entry.changes.every((change) => change.field === 'age')).toBe(
+        true
+      );
+    }
+    expect(history[0].changes[0].old).toBe(28); // current vs v3
+    expect(history[0].changes[0].new).toBe(30);
+    expect(history[1].changes[0].old).toBe(25); // v1 vs v2
+    expect(history[1].changes[0].new).toBe(28);
+    expect(history[2].changes[0].new).toBe(25); // creation
   });
 
   it('should apply pagination to a record with no prior versions', async () => {

--- a/src/routes/download/index.ts
+++ b/src/routes/download/index.ts
@@ -189,19 +189,10 @@ router.get('/form/records/:id/history', async (req, res) => {
     const record: Record = await Record.findOne({
       _id: req.params.id,
       archived: { $ne: true },
-    })
-      .populate({
-        path: 'versions',
-        model: 'Version',
-        populate: {
-          path: 'createdBy',
-          model: 'User',
-        },
-      })
-      .populate({
-        path: 'resource',
-        model: 'Resource',
-      });
+    }).populate({
+      path: 'resource',
+      model: 'Resource',
+    });
     if (!record) {
       return res.status(404).send(req.t('common.errors.dataNotFound'));
     }

--- a/src/routes/download/index.ts
+++ b/src/routes/download/index.ts
@@ -210,7 +210,7 @@ router.get('/form/records/:id/history', async (req, res) => {
     if (form) {
       record.form = form;
       const meta: RecordHistoryMeta = {
-        form: form.name,
+        form: form.name as string,
         record: record.incrementalId,
         fields: filters.fields?.join(',') || '',
         fromDate: filters.fromDate

--- a/src/schema/query/recordHistory.query.ts
+++ b/src/schema/query/recordHistory.query.ts
@@ -4,6 +4,7 @@ import {
   GraphQLError,
   GraphQLList,
   GraphQLString,
+  GraphQLInt,
 } from 'graphql';
 import { HistoryVersionType } from '../types';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
@@ -15,10 +16,15 @@ import { Types } from 'mongoose';
 import { Context } from '@server/apollo/context';
 import { getErrorMessage, getErrorStack } from '@utils/error';
 
+/** Maximum number of history entries that can be requested per page */
+const MAX_HISTORY_PAGE_LIMIT = 100;
+
 /** Arguments for the recordHistory query */
 type RecordHistoryArgs = {
   id: string | Types.ObjectId;
   lang?: string;
+  page?: number;
+  limit?: number;
 };
 
 /**
@@ -30,6 +36,8 @@ export default {
   args: {
     id: { type: new GraphQLNonNull(GraphQLID) },
     lang: { type: GraphQLString },
+    page: { type: GraphQLInt },
+    limit: { type: GraphQLInt },
   },
   async resolve(parent, args: RecordHistoryArgs, context: Context) {
     graphQLAuthCheck(context);
@@ -40,20 +48,12 @@ export default {
       }
 
       const user = context.user;
-      // Get data
-      const record: Record = await Record.findById(args.id)
-        .populate({
-          path: 'versions',
-          model: 'Version',
-          populate: {
-            path: 'createdBy',
-            model: 'User',
-          },
-        })
-        .populate({
-          path: 'resource',
-          model: 'Resource',
-        });
+      // Get data. Versions are fetched lazily by RecordHistory, only for the
+      // requested page, instead of being populated in full here.
+      const record: Record = await Record.findById(args.id).populate({
+        path: 'resource',
+        model: 'Resource',
+      });
       if (!record) {
         throw new GraphQLError(
           context.i18next.i18n.t('common.errors.permissionNotGranted')
@@ -76,11 +76,20 @@ export default {
 
       // Create the history and return it
       record.form = form;
+      const pagination =
+        args.page !== undefined || args.limit !== undefined
+          ? {
+              page: args.page,
+              limit: args.limit
+                ? Math.min(args.limit, MAX_HISTORY_PAGE_LIMIT)
+                : undefined,
+            }
+          : undefined;
       const history = await new RecordHistory(record, {
         translate: context.i18next.i18n.t,
         ability,
         context,
-      }).getHistory();
+      }).getHistory(pagination);
       for (const version of history) {
         for (const change of version.changes) {
           if (change.new) change.new = JSON.stringify(change.new);

--- a/src/schema/query/recordHistory.query.ts
+++ b/src/schema/query/recordHistory.query.ts
@@ -23,6 +23,7 @@ type RecordHistoryArgs = {
   lang?: string;
   first?: number;
   skip?: number;
+  fields?: string[];
 };
 
 /**
@@ -36,6 +37,7 @@ export default {
     lang: { type: GraphQLString },
     first: { type: GraphQLInt },
     skip: { type: GraphQLInt },
+    fields: { type: new GraphQLList(GraphQLString) },
   },
   async resolve(parent, args: RecordHistoryArgs, context: Context) {
     graphQLAuthCheck(context);
@@ -78,15 +80,15 @@ export default {
 
       // Create the history and return it
       record.form = form;
-      const pagination =
-        args.first !== undefined || args.skip !== undefined
-          ? { skip: args.skip, limit: args.first }
-          : undefined;
       const history = await new RecordHistory(record, {
         translate: context.i18next.i18n.t,
         ability,
         context,
-      }).getHistory(pagination);
+      }).getHistory({
+        skip: args.skip,
+        limit: args.first,
+        fields: args.fields,
+      });
       for (const version of history) {
         for (const change of version.changes) {
           if (change.new) change.new = JSON.stringify(change.new);

--- a/src/schema/query/recordHistory.query.ts
+++ b/src/schema/query/recordHistory.query.ts
@@ -15,16 +15,14 @@ import { graphQLAuthCheck } from '@schema/shared';
 import { Types } from 'mongoose';
 import { Context } from '@server/apollo/context';
 import { getErrorMessage, getErrorStack } from '@utils/error';
-
-/** Maximum number of history entries that can be requested per page */
-const MAX_HISTORY_PAGE_LIMIT = 100;
+import checkPageSize from '@utils/schema/errors/checkPageSize.util';
 
 /** Arguments for the recordHistory query */
 type RecordHistoryArgs = {
   id: string | Types.ObjectId;
   lang?: string;
-  page?: number;
-  limit?: number;
+  first?: number;
+  skip?: number;
 };
 
 /**
@@ -36,11 +34,15 @@ export default {
   args: {
     id: { type: new GraphQLNonNull(GraphQLID) },
     lang: { type: GraphQLString },
-    page: { type: GraphQLInt },
-    limit: { type: GraphQLInt },
+    first: { type: GraphQLInt },
+    skip: { type: GraphQLInt },
   },
   async resolve(parent, args: RecordHistoryArgs, context: Context) {
     graphQLAuthCheck(context);
+    // Make sure that the page size is not too important
+    if (args.first) {
+      checkPageSize(args.first);
+    }
     try {
       // Setting language, if provided
       if (args.lang) {
@@ -77,13 +79,8 @@ export default {
       // Create the history and return it
       record.form = form;
       const pagination =
-        args.page !== undefined || args.limit !== undefined
-          ? {
-              page: args.page,
-              limit: args.limit
-                ? Math.min(args.limit, MAX_HISTORY_PAGE_LIMIT)
-                : undefined,
-            }
+        args.first !== undefined || args.skip !== undefined
+          ? { skip: args.skip, limit: args.first }
           : undefined;
       const history = await new RecordHistory(record, {
         translate: context.i18next.i18n.t,

--- a/src/schema/query/recordHistory.query.ts
+++ b/src/schema/query/recordHistory.query.ts
@@ -6,6 +6,7 @@ import {
   GraphQLString,
   GraphQLInt,
 } from 'graphql';
+import { GraphQLDateTime } from 'graphql-scalars';
 import { HistoryVersionType } from '../types';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
 import { RecordHistory } from '@utils/history';
@@ -24,6 +25,8 @@ type RecordHistoryArgs = {
   first?: number;
   skip?: number;
   fields?: string[];
+  fromDate?: Date;
+  toDate?: Date;
 };
 
 /**
@@ -38,6 +41,8 @@ export default {
     first: { type: GraphQLInt },
     skip: { type: GraphQLInt },
     fields: { type: new GraphQLList(GraphQLString) },
+    fromDate: { type: GraphQLDateTime },
+    toDate: { type: GraphQLDateTime },
   },
   async resolve(parent, args: RecordHistoryArgs, context: Context) {
     graphQLAuthCheck(context);
@@ -88,6 +93,8 @@ export default {
         skip: args.skip,
         limit: args.first,
         fields: args.fields,
+        fromDate: args.fromDate,
+        toDate: args.toDate,
       });
       for (const version of history) {
         for (const change of version.changes) {

--- a/src/utils/history/recordHistory.ts
+++ b/src/utils/history/recordHistory.ts
@@ -242,24 +242,31 @@ export class RecordHistory {
    * and the record's current data. The returned list is reversed so index 0
    * is the most recent change.
    *
-   * When paginating or filtering by fields, entries without any remaining
-   * change are dropped, and skip / limit apply to the remaining displayable
-   * entries: a page always contains up to `limit` non-empty entries. Entries
-   * are computed most-recent-first in batches, fetching only the version
-   * documents needed, until the page is filled or history is exhausted.
+   * When paginating or filtering, entries outside the date range or without
+   * any remaining change are dropped, and skip / limit apply to the remaining
+   * displayable entries: a page always contains up to `limit` non-empty
+   * entries. Entries are computed most-recent-first in batches, fetching only
+   * the version documents needed, until the page is filled or history is
+   * exhausted.
    *
    * @param options optional options
    * @param options.skip number of history entries to skip
    * @param options.limit number of history entries per page
    * @param options.fields when provided, only keep changes on those fields
+   * @param options.fromDate when provided, only keep entries from that date
+   * @param options.toDate when provided, only keep entries up to that date
    * @returns A list of changes
    */
   async getHistory(options?: {
     skip?: number;
     limit?: number;
     fields?: string[];
+    fromDate?: Date;
+    toDate?: Date;
   }) {
     const fields = options?.fields?.length ? options.fields : undefined;
+    const fromDate = options?.fromDate;
+    const toDate = options?.toDate;
     const paginating =
       options?.skip !== undefined || options?.limit !== undefined;
     const skip = paginating ? options.skip || 0 : 0;
@@ -272,15 +279,22 @@ export class RecordHistory {
     // remove changes whose formatted old & new values are equal.
     const dropEmpty = paginating || !!fields;
 
-    const applyFieldsFilter = (entries: RecordHistoryType) => {
+    const applyFilters = (entries: RecordHistoryType) => {
+      let filtered = entries;
+      if (fromDate || toDate) {
+        filtered = filtered.filter((entry) => {
+          const date = new Date(entry.createdAt);
+          return !(fromDate && date < fromDate) && !(toDate && date > toDate);
+        });
+      }
       if (fields) {
-        for (const entry of entries) {
+        for (const entry of filtered) {
           entry.changes = entry.changes.filter((change) =>
             fields.includes(change.field)
           );
         }
       }
-      return entries;
+      return filtered;
     };
 
     const filteredData = pick(
@@ -300,7 +314,7 @@ export class RecordHistory {
           changes,
         },
       ];
-      entries = await this.formatValues(applyFieldsFilter(entries));
+      entries = await this.formatValues(applyFilters(entries));
       if (dropEmpty) {
         entries = entries.filter((entry) => entry.changes.length);
       }
@@ -329,7 +343,11 @@ export class RecordHistory {
         versionIds,
         filteredData
       );
-      const formatted = await this.formatValues(applyFieldsFilter(raw));
+      // Entries are ordered most recent first: once one is older than
+      // fromDate, all the remaining history is out of range too
+      const exhausted =
+        fromDate && raw.some((entry) => new Date(entry.createdAt) < fromDate);
+      const formatted = await this.formatValues(applyFilters(raw));
       for (const entry of formatted) {
         if (dropEmpty && !entry.changes.length) continue;
         if (seen >= skip && result.length < limit) {
@@ -337,6 +355,7 @@ export class RecordHistory {
         }
         seen++;
       }
+      if (exhausted) break;
     }
     return result;
   }

--- a/src/utils/history/recordHistory.ts
+++ b/src/utils/history/recordHistory.ts
@@ -240,16 +240,49 @@ export class RecordHistory {
    * entry 0 is the initial creation diff, entries 1..N-1 are diffs between
    * consecutive versions, and entry N is the diff between the last version
    * and the record's current data. The returned list is reversed so index 0
-   * is the most recent change. When pagination is provided, only the version
-   * documents strictly required to compute the requested slice are fetched
-   * from the database, instead of the record's entire version history.
+   * is the most recent change.
    *
-   * @param pagination optional pagination options
-   * @param pagination.skip number of history entries to skip
-   * @param pagination.limit number of history entries per page
+   * When paginating or filtering by fields, entries without any remaining
+   * change are dropped, and skip / limit apply to the remaining displayable
+   * entries: a page always contains up to `limit` non-empty entries. Entries
+   * are computed most-recent-first in batches, fetching only the version
+   * documents needed, until the page is filled or history is exhausted.
+   *
+   * @param options optional options
+   * @param options.skip number of history entries to skip
+   * @param options.limit number of history entries per page
+   * @param options.fields when provided, only keep changes on those fields
    * @returns A list of changes
    */
-  async getHistory(pagination?: { skip?: number; limit?: number }) {
+  async getHistory(options?: {
+    skip?: number;
+    limit?: number;
+    fields?: string[];
+  }) {
+    const fields = options?.fields?.length ? options.fields : undefined;
+    const paginating =
+      options?.skip !== undefined || options?.limit !== undefined;
+    const skip = paginating ? options.skip || 0 : 0;
+    const limit = paginating
+      ? options.limit || RecordHistory.defaultPageLimit
+      : Infinity;
+    // Entries left without changes cannot be displayed, so they are dropped
+    // whenever the caller paginates or filters, and don't count towards
+    // skip / limit. Emptiness is only known after formatValues, which can
+    // remove changes whose formatted old & new values are equal.
+    const dropEmpty = paginating || !!fields;
+
+    const applyFieldsFilter = (entries: RecordHistoryType) => {
+      if (fields) {
+        for (const entry of entries) {
+          entry.changes = entry.changes.filter((change) =>
+            fields.includes(change.field)
+          );
+        }
+      }
+      return entries;
+    };
+
     const filteredData = pick(
       this.record,
       this.record.accessibleFieldsBy(this.options.ability)
@@ -260,39 +293,72 @@ export class RecordHistory {
     // No prior versions: the only possible entry is the creation of the record
     if (N === 0) {
       const changes = this.getDifference(null, filteredData);
-      const entries: RecordHistoryType = [
+      let entries: RecordHistoryType = [
         {
           createdAt: this.record.createdAt,
           createdBy: this.record._createdBy?.user?.name,
           changes,
         },
       ];
-      const page = pagination
-        ? entries.slice(
-            pagination.skip || 0,
-            (pagination.skip || 0) +
-              (pagination.limit || RecordHistory.defaultPageLimit)
-          )
-        : entries;
-      return this.formatValues(page);
+      entries = await this.formatValues(applyFieldsFilter(entries));
+      if (dropEmpty) {
+        entries = entries.filter((entry) => entry.changes.length);
+      }
+      return entries.slice(skip, skip + limit);
     }
 
-    // Determine which chronological entries (e = 0..N) are requested, expressed
-    // in reversed (most-recent-first) order matching the public API.
-    let eMin = 0;
-    let eMax = N;
-    if (pagination) {
-      const limit = pagination.limit || RecordHistory.defaultPageLimit;
-      const skip = pagination.skip || 0;
-      // Reversed index range is [0, N] (N+1 total entries) - a page starting
-      // past the last valid index has nothing to return.
-      if (skip > N) return [];
-      const rStart = skip;
-      const rEnd = Math.min(skip + limit - 1, N);
-      eMax = N - rStart;
-      eMin = N - rEnd;
-    }
+    const result: RecordHistoryType = [];
+    // Displayable entries encountered so far, to consume `skip`
+    let seen = 0;
+    // Reversed index of the next entry to compute (0 = most recent, N = creation)
+    let nextR = 0;
+    // The first batch covers exactly the requested window, so when no entry is
+    // dropped a page costs a single versions query, as if slicing directly.
+    // Follow-up batches double in size to bound the number of queries when
+    // most entries are filtered out.
+    let batchSize = Math.min(skip + limit, N + 1);
+    while (nextR <= N && result.length < limit) {
+      const rStart = nextR;
+      const rEnd = Math.min(nextR + batchSize - 1, N);
+      nextR = rEnd + 1;
+      batchSize *= 2;
 
+      const raw = await this.getEntries(
+        N - rEnd,
+        N - rStart,
+        versionIds,
+        filteredData
+      );
+      const formatted = await this.formatValues(applyFieldsFilter(raw));
+      for (const entry of formatted) {
+        if (dropEmpty && !entry.changes.length) continue;
+        if (seen >= skip && result.length < limit) {
+          result.push(entry);
+        }
+        seen++;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Builds the raw (unformatted) history entries for the chronological
+   * indices [eMin, eMax], fetching only the version documents strictly
+   * required to compute that range.
+   *
+   * @param eMin first chronological entry index (0 = creation diff)
+   * @param eMax last chronological entry index (N = current data diff)
+   * @param versionIds ids of all the record's versions, in chronological order
+   * @param filteredData record's current data, restricted to accessible fields
+   * @returns The entries for the range, most recent first
+   */
+  private async getEntries(
+    eMin: number,
+    eMax: number,
+    versionIds: any[],
+    filteredData: any
+  ): Promise<RecordHistoryType> {
+    const N = versionIds.length;
     // Only fetch the version documents strictly needed to compute entries [eMin, eMax]
     const vStart = Math.max(0, eMin - 1);
     const vEnd = Math.min(N - 1, eMax);
@@ -345,8 +411,7 @@ export class RecordHistory {
       }
     }
 
-    const formatted = await this.formatValues(res.reverse());
-    return formatted;
+    return res.reverse();
   }
 
   /**

--- a/src/utils/history/recordHistory.ts
+++ b/src/utils/history/recordHistory.ts
@@ -1,4 +1,4 @@
-import { Record, User, Role, ReferenceData } from '@models';
+import { Record, User, Role, ReferenceData, Version } from '@models';
 import {
   Change,
   RecordHistory as RecordHistoryType,
@@ -24,6 +24,9 @@ import { resolveLocalizedString } from '@utils/i18n/resolveLocalizedString';
  */
 export class RecordHistory {
   fields: any[] = [];
+
+  /** Default number of history entries returned per page, when a limit is not specified */
+  private static defaultPageLimit = 20;
 
   /**
    * Initializes a RecordHistory object with the given record
@@ -231,60 +234,118 @@ export class RecordHistory {
   }
 
   /**
-   * Gets the list of changes per version of a record
+   * Gets the list of changes per version of a record.
    *
+   * Entries are chronologically indexed 0..N (N = number of stored versions):
+   * entry 0 is the initial creation diff, entries 1..N-1 are diffs between
+   * consecutive versions, and entry N is the diff between the last version
+   * and the record's current data. The returned list is reversed so index 0
+   * is the most recent change. When pagination is provided, only the version
+   * documents strictly required to compute the requested slice are fetched
+   * from the database, instead of the record's entire version history.
+   *
+   * @param pagination optional pagination options
+   * @param pagination.page requested page, 1-indexed
+   * @param pagination.limit number of history entries per page
    * @returns A list of changes
    */
-  async getHistory() {
-    const res: RecordHistoryType = [];
-    const versions =
-      this.record.versions?.map((v) => ({
-        ...v.toObject({ minimize: false }),
-        data: pick(v, this.record.accessibleFieldsBy(this.options.ability))
-          .data,
-      })) || [];
+  async getHistory(pagination?: { page?: number; limit?: number }) {
     const filteredData = pick(
       this.record,
       this.record.accessibleFieldsBy(this.options.ability)
     ).data;
-    let changes: any;
-    if (versions.length === 0) {
-      changes = this.getDifference(null, filteredData);
-      res.push({
-        createdAt: this.record.createdAt,
-        createdBy: this.record._createdBy?.user?.name,
-        changes,
-      });
+    const versionIds: any[] = this.record.versions || [];
+    const N = versionIds.length;
 
-      const formatted = await this.formatValues(res);
-      return formatted;
+    // No prior versions: the only possible entry is the creation of the record
+    if (N === 0) {
+      const changes = this.getDifference(null, filteredData);
+      const entries: RecordHistoryType = [
+        {
+          createdAt: this.record.createdAt,
+          createdBy: this.record._createdBy?.user?.name,
+          changes,
+        },
+      ];
+      const page = pagination
+        ? entries.slice(
+            ((pagination.page || 1) - 1) *
+              (pagination.limit || RecordHistory.defaultPageLimit),
+            (pagination.page || 1) *
+              (pagination.limit || RecordHistory.defaultPageLimit)
+          )
+        : entries;
+      return this.formatValues(page);
     }
-    changes = this.getDifference(null, versions[0].data);
-    res.push({
-      createdAt: versions[0].createdAt,
-      createdBy: this.record._createdBy?.user?.name,
-      changes,
-      version: versions[0],
-    });
 
-    for (let i = 1; i < versions.length; i++) {
-      changes = this.getDifference(versions[i - 1].data, versions[i].data);
-      res.push({
-        createdAt: versions[i].createdAt,
-        createdBy: versions[i - 1].createdBy?.name,
-        changes,
-        version: versions[i],
-      });
+    // Determine which chronological entries (e = 0..N) are requested, expressed
+    // in reversed (most-recent-first) order matching the public API.
+    let eMin = 0;
+    let eMax = N;
+    if (pagination) {
+      const limit = pagination.limit || RecordHistory.defaultPageLimit;
+      const page = pagination.page || 1;
+      const skip = (page - 1) * limit;
+      // Reversed index range is [0, N] (N+1 total entries) - a page starting
+      // past the last valid index has nothing to return.
+      if (skip > N) return [];
+      const rStart = skip;
+      const rEnd = Math.min(skip + limit - 1, N);
+      eMax = N - rStart;
+      eMin = N - rEnd;
     }
-    changes = this.getDifference(
-      versions[versions.length - 1].data,
-      filteredData
+
+    // Only fetch the version documents strictly needed to compute entries [eMin, eMax]
+    const vStart = Math.max(0, eMin - 1);
+    const vEnd = Math.min(N - 1, eMax);
+    const neededIds = versionIds.slice(vStart, vEnd + 1);
+
+    const fetchedVersions = await Version.find({
+      _id: { $in: neededIds },
+    }).populate({ path: 'createdBy', model: 'User' });
+    const fetchedById = new Map(
+      fetchedVersions.map((v: any) => [String(v._id), v])
     );
-    res.push({
-      createdAt: this.record.modifiedAt,
-      createdBy: versions[versions.length - 1].createdBy?.name,
-      changes,
+    // Mongo doesn't preserve $in order, so re-map to match neededIds
+    const versions = neededIds.map((id) => {
+      const v = fetchedById.get(String(id));
+      return {
+        ...v.toObject({ minimize: false }),
+        data: pick(v, this.record.accessibleFieldsBy(this.options.ability))
+          .data,
+      };
     });
+    // versions[idx - vStart] is the version at original array index `idx`
+    const getVersion = (idx: number) => versions[idx - vStart];
+
+    const res: RecordHistoryType = [];
+    for (let e = eMin; e <= eMax; e++) {
+      if (e === 0) {
+        const v0 = getVersion(0);
+        res.push({
+          createdAt: v0.createdAt,
+          createdBy: this.record._createdBy?.user?.name,
+          changes: this.getDifference(null, v0.data),
+          version: v0,
+        });
+      } else if (e === N) {
+        const vLast = getVersion(N - 1);
+        res.push({
+          createdAt: this.record.modifiedAt,
+          createdBy: vLast.createdBy?.name,
+          changes: this.getDifference(vLast.data, filteredData),
+        });
+      } else {
+        const vPrev = getVersion(e - 1);
+        const vCurr = getVersion(e);
+        res.push({
+          createdAt: vCurr.createdAt,
+          createdBy: vPrev.createdBy?.name,
+          changes: this.getDifference(vPrev.data, vCurr.data),
+          version: vCurr,
+        });
+      }
+    }
 
     const formatted = await this.formatValues(res.reverse());
     return formatted;

--- a/src/utils/history/recordHistory.ts
+++ b/src/utils/history/recordHistory.ts
@@ -245,11 +245,11 @@ export class RecordHistory {
    * from the database, instead of the record's entire version history.
    *
    * @param pagination optional pagination options
-   * @param pagination.page requested page, 1-indexed
+   * @param pagination.skip number of history entries to skip
    * @param pagination.limit number of history entries per page
    * @returns A list of changes
    */
-  async getHistory(pagination?: { page?: number; limit?: number }) {
+  async getHistory(pagination?: { skip?: number; limit?: number }) {
     const filteredData = pick(
       this.record,
       this.record.accessibleFieldsBy(this.options.ability)
@@ -269,9 +269,8 @@ export class RecordHistory {
       ];
       const page = pagination
         ? entries.slice(
-            ((pagination.page || 1) - 1) *
-              (pagination.limit || RecordHistory.defaultPageLimit),
-            (pagination.page || 1) *
+            pagination.skip || 0,
+            (pagination.skip || 0) +
               (pagination.limit || RecordHistory.defaultPageLimit)
           )
         : entries;
@@ -284,8 +283,7 @@ export class RecordHistory {
     let eMax = N;
     if (pagination) {
       const limit = pagination.limit || RecordHistory.defaultPageLimit;
-      const page = pagination.page || 1;
-      const skip = (page - 1) * limit;
+      const skip = pagination.skip || 0;
       // Reversed index range is [0, N] (N+1 total entries) - a page starting
       // past the last valid index has nothing to return.
       if (skip > N) return [];


### PR DESCRIPTION
# Description

Improves performance and reliability of the `recordHistory` query: Adds pagination to the record history view and fixes rendering issues that could crash it or show incorrect data.

## Useful links

- Ticket: [AB#134835](https://dev.azure.com/WHOHQ/2888b816-2d79-49ef-a86e-561e6cd456a0/_workitems/edit/134835) — *(insert Azure Boards link, e.g. `https://dev.azure.com/<org>/<project>/_workitems/edit/134835`)*

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?


verified directly against a real test record

- [x] Pagination returns correct page sizes and stops cleanly at the last page
- [x] Out-of-range pages return an empty array instead of throwing
- [x] Only the needed `Version` documents are fetched per page (not the full history)

## Screenshots

[Screencast_20260706_022924.webm](https://github.com/user-attachments/assets/a2dc97c4-7d6b-4ded-8f34-41fcebd7eca9)

# Checklist:

( * == Mandatory )

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [x] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
