### PR TITLE
MedEvac: Common Services user filter + distribution list alongside separate email

### DIFF
--- a/src/models/emailNotification.model.ts
+++ b/src/models/emailNotification.model.ts
@@ -142,6 +142,7 @@ export const emailNotificationSchema = new Schema<EmailNotification>(
         textStyle: { type: mongoose.Schema.Types.Mixed },
         sendAsAttachment: { type: Boolean, default: false },
         individualEmail: { type: Boolean, default: false },
+        individualEmailToDistributionList: { type: Boolean, default: false },
         navigateToPage: {
           type: Boolean,
           default: false,

--- a/src/models/emailNotification.model.ts
+++ b/src/models/emailNotification.model.ts
@@ -36,6 +36,7 @@ export interface Dataset {
   sendAsAttachment: boolean;
   individualEmail: boolean;
   individualEmailFields?: any[];
+  csFilter?: any;
   navigateToPage: boolean;
   navigateSettings: {
     field: string;
@@ -134,6 +135,7 @@ export const emailNotificationSchema = new Schema<EmailNotification>(
           filter: { type: mongoose.Schema.Types.Mixed },
         },
         individualEmailFields: [{ type: mongoose.Schema.Types.Mixed }],
+        csFilter: { type: mongoose.Schema.Types.Mixed },
         pageSize: { type: mongoose.Schema.Types.Number },
         tableStyle: { type: mongoose.Schema.Types.Mixed },
         blockType: { type: mongoose.Schema.Types.Mixed },

--- a/src/models/emailNotification.model.ts
+++ b/src/models/emailNotification.model.ts
@@ -36,6 +36,7 @@ export interface Dataset {
   sendAsAttachment: boolean;
   individualEmail: boolean;
   individualEmailFields?: any[];
+  individualEmailToDistributionList?: boolean;
   csFilter?: any;
   navigateToPage: boolean;
   navigateSettings: {

--- a/src/schema/inputs/emailNotification.input.ts
+++ b/src/schema/inputs/emailNotification.input.ts
@@ -64,6 +64,7 @@ export const DatasetInputType = new GraphQLInputObjectType({
     sendAsAttachment: { type: GraphQLBoolean },
     individualEmail: { type: GraphQLBoolean },
     individualEmailFields: { type: new GraphQLList(GraphQLJSON) },
+    individualEmailToDistributionList: { type: GraphQLBoolean },
     csFilter: { type: GraphQLJSON },
     pageSize: { type: GraphQLInt },
     navigateToPage: { type: GraphQLBoolean, defaultValue: false },

--- a/src/schema/inputs/emailNotification.input.ts
+++ b/src/schema/inputs/emailNotification.input.ts
@@ -64,6 +64,7 @@ export const DatasetInputType = new GraphQLInputObjectType({
     sendAsAttachment: { type: GraphQLBoolean },
     individualEmail: { type: GraphQLBoolean },
     individualEmailFields: { type: new GraphQLList(GraphQLJSON) },
+    csFilter: { type: GraphQLJSON },
     pageSize: { type: GraphQLInt },
     navigateToPage: { type: GraphQLBoolean, defaultValue: false },
     navigateSettings: { type: GraphQLJSON },

--- a/src/schema/mutation/addEmailNotification.mutation.ts
+++ b/src/schema/mutation/addEmailNotification.mutation.ts
@@ -10,7 +10,6 @@ import {
   EmailNotificationInputType,
 } from '@schema/inputs/emailNotification.input';
 import extendAbilityForApplications from '@security/extendAbilityForApplication';
-import { cloneDeep } from 'lodash';
 import { getErrorMessage, getErrorStack } from '@utils/error';
 import { createCronJob } from '@server/emailNotificationScheduler';
 import { isValidCronExpression } from '@utils/validators';
@@ -42,13 +41,11 @@ export default {
       //     );
       //   }
       // }
-      // Only count as a dataset if it has a resource
-      const datasetsCount = cloneDeep(args.notification.datasets).filter(
-        ({ resource, reference }) => resource || reference
-      ).length;
-      // Individual email count
+      // A notification needs at least one recipient source: a distribution
+      // list, or at least one send-separate dataset (which supplies its own
+      // per-row recipients).
       let individualCount = 0;
-      for (const dataset of args.notification.datasets) {
+      for (const dataset of args.notification.datasets ?? []) {
         if (
           (dataset.resource || dataset.reference) &&
           dataset.individualEmail
@@ -56,18 +53,10 @@ export default {
           individualCount += 1;
         }
       }
-      let allSeparate = false;
-      if (datasetsCount === individualCount) {
-        allSeparate = true;
-      }
 
       if (
         !(args.notification.isDraft || args.notification.isDeleted === 1) &&
-        // (!args.notification.emailDistributionList.name ||
-        //   (!args.notification.emailDistributionList.to.resource &&
-        //     args.notification.emailDistributionList.to.inputEmails.length ===
-        //       0)) &&
-        !allSeparate &&
+        individualCount === 0 &&
         !args.notification.emailDistributionList
       ) {
         throw new GraphQLError(context.i18next.t('common.errors.dataNotFound'));

--- a/src/schema/mutation/editEmailNotification.mutation.ts
+++ b/src/schema/mutation/editEmailNotification.mutation.ts
@@ -12,7 +12,6 @@ import { Types } from 'mongoose';
 import extendAbilityForApplications from '@security/extendAbilityForApplication';
 import { AppAbility } from '@security/defineUserAbility';
 import { EmailNotificationReturn } from '@schema/types/emailNotification.type';
-import { cloneDeep } from 'lodash';
 import { getErrorMessage, getErrorStack } from '@utils/error';
 import {
   createCronJob,
@@ -59,36 +58,22 @@ export default {
       //   }
       // }
       if (args.notification) {
-        // Can't do this type of type check on type level
-        let allSeparate = false;
-        // Only count as a dataset if it has a resource
-        if (args.notification.datasets) {
-          const datasetsCount =
-            cloneDeep(args.notification.datasets)?.filter(
-              ({ resource, reference }) => resource || reference
-            ).length ?? 0;
-          // Individual email count
-          let individualCount = 0;
-          for (const dataset of args.notification.datasets) {
-            if (
-              (dataset.resource || dataset.reference) &&
-              dataset.individualEmail
-            ) {
-              individualCount += 1;
-            }
-          }
-          if (datasetsCount === individualCount) {
-            allSeparate = true;
+        // A notification needs at least one recipient source: a distribution
+        // list, or at least one send-separate dataset (which supplies its own
+        // per-row recipients).
+        let individualCount = 0;
+        for (const dataset of args.notification.datasets ?? []) {
+          if (
+            (dataset.resource || dataset.reference) &&
+            dataset.individualEmail
+          ) {
+            individualCount += 1;
           }
         }
 
         if (
           !(args.notification.isDraft || args.notification.isDeleted === 1) &&
-          // (!args.notification.emailDistributionList.name ||
-          //   (!args.notification.emailDistributionList.to.resource &&
-          //     args.notification.emailDistributionList.to.inputEmails.length ===
-          //       0)) &&
-          !allSeparate &&
+          individualCount === 0 &&
           !args.notification.emailDistributionList
         ) {
           throw new GraphQLError(

--- a/src/schema/types/emailNotification.type.ts
+++ b/src/schema/types/emailNotification.type.ts
@@ -43,6 +43,7 @@ export const DatasetType = new GraphQLObjectType({
     sendAsAttachment: { type: GraphQLBoolean },
     individualEmail: { type: GraphQLBoolean },
     individualEmailFields: { type: new GraphQLList(GraphQLJSON) },
+    csFilter: { type: GraphQLJSON },
     pageSize: { type: GraphQLInt },
     navigateToPage: { type: GraphQLBoolean, defaultValue: false },
     navigateSettings: { type: GraphQLJSON },

--- a/src/schema/types/emailNotification.type.ts
+++ b/src/schema/types/emailNotification.type.ts
@@ -43,6 +43,7 @@ export const DatasetType = new GraphQLObjectType({
     sendAsAttachment: { type: GraphQLBoolean },
     individualEmail: { type: GraphQLBoolean },
     individualEmailFields: { type: new GraphQLList(GraphQLJSON) },
+    individualEmailToDistributionList: { type: GraphQLBoolean },
     csFilter: { type: GraphQLJSON },
     pageSize: { type: GraphQLInt },
     navigateToPage: { type: GraphQLBoolean, defaultValue: false },


### PR DESCRIPTION
# Description

Adds two fields to email notification datasets. `csFilter` holds a filter descriptor used to select recipients from the Common Services user directory, and `individualEmailToDistributionList` lets a send-separate dataset also be delivered to the notification's distribution list. Both are plumbed through the Mongoose model, GraphQL input and GraphQL type.

Validation on `addEmailNotification` / `editEmailNotification` is rewritten so a send-separate notification can be saved without a distribution list, while still requiring at least one recipient source overall. This replaces the previous check, which incorrectly passed notifications that had no recipients at all.

## Useful links

- https://github.com/ReliefApplications/ems-frontend/pull/2919

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( \* == Mandatory )

- [ ] \* I have set myself as assignee of the pull request
- [ ] \* My code follows the style guidelines of this project
- [ ] \* Linting does not generate new warnings
- [ ] \* I have performed a self-review of my own code
- [ ] \* I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [ ] \* I have commented my code, particularly in hard-to-understand areas
- [ ] \* I have put JSDoc comment in all required places
- [ ] \* My changes generate no new warnings
- [ ] \* I have included screenshots describing my changes if relevant
- [ ] \* I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] \* New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
