### PR TITLE
MedEvac: dual-language email notifications

### DIFF
--- a/src/i18n/uk.json
+++ b/src/i18n/uk.json
@@ -142,7 +142,7 @@
 		"emailNotification": {
 			"add": {
 				"errors": {
-					"invalidCron": "The cron expression used in the scheduler is invalid"
+					"invalidCron": "Вираз cron, використаний у планувальнику, недійсний"
 				}
 			}
 		},

--- a/src/models/emailNotification.model.ts
+++ b/src/models/emailNotification.model.ts
@@ -84,6 +84,7 @@ export interface EmailNotification extends Document {
   applicationId: mongoose.Schema.Types.ObjectId;
   createdBy: { name: string; email: string };
   notificationType: string;
+  language?: string;
   datasets: Dataset[];
   emailDistributionList: mongoose.Schema.Types.ObjectId | EmailDistributionList; // Reference to EmailDistributionList
   subscriptionList: string[];
@@ -116,6 +117,9 @@ export const emailNotificationSchema = new Schema<EmailNotification>(
       type: String,
       enum: Object.values(notificationsType),
       required: true,
+    },
+    language: {
+      type: String,
     },
     schedule: {
       scheduleEnabled: { type: mongoose.Schema.Types.Boolean },

--- a/src/schema/inputs/emailNotification.input.ts
+++ b/src/schema/inputs/emailNotification.input.ts
@@ -19,6 +19,7 @@ export type EmailNotificationArgs = {
   name: string;
   schedule: EmailNotificationSchedule;
   notificationType: string;
+  language?: string;
   applicationId: string | Types.ObjectId;
   datasets: any[];
   emailLayout: string | Types.ObjectId;
@@ -134,6 +135,7 @@ export const EmailNotificationInputType = new GraphQLInputObjectType({
     schedule: { type: EmailNotificationScheduleInputType },
     applicationId: { type: new GraphQLNonNull(GraphQLID) },
     notificationType: { type: GraphQLString },
+    language: { type: GraphQLString },
     datasets: { type: new GraphQLList(DatasetInputType) },
     emailLayout: { type: GraphQLID },
     emailDistributionList: {

--- a/src/schema/mutation/addEmailNotification.mutation.ts
+++ b/src/schema/mutation/addEmailNotification.mutation.ts
@@ -68,6 +68,7 @@ export default {
         createdBy: { name: context.user.name, email: context.user.username },
         applicationId: args.notification.applicationId,
         notificationType: args.notification.notificationType,
+        language: args.notification.language,
         datasets: args.notification.datasets,
         emailLayout: args.notification.emailLayout,
         emailDistributionList: args.notification.emailDistributionList,

--- a/src/schema/mutation/editEmailNotification.mutation.ts
+++ b/src/schema/mutation/editEmailNotification.mutation.ts
@@ -94,6 +94,7 @@ export default {
           },
           notificationType: args.notification.notificationType,
           applicationId: args.notification.applicationId,
+          language: args.notification.language,
           datasets: args.notification.datasets,
           emailLayout: args.notification.emailLayout,
           emailDistributionList: args.notification.emailDistributionList,

--- a/src/schema/types/emailNotification.type.ts
+++ b/src/schema/types/emailNotification.type.ts
@@ -80,6 +80,7 @@ export const EmailNotificationType = new GraphQLObjectType({
     createdBy: { type: GraphQLJSON },
     schedule: { type: ScheduleType },
     notificationType: { type: GraphQLString },
+    language: { type: GraphQLString },
     datasets: { type: new GraphQLList(DatasetType) },
     emailLayout: { type: GraphQLID },
     emailDistributionList: { type: GraphQLID },


### PR DESCRIPTION
# Description

Plumbs a `language` field through `EmailNotification` (model, GraphQL input, GraphQL type, and the add/edit mutations) so a notification can record which language its content should be resolved in. Also translates the medevac email-notification keys in `uk.json`.

## Useful links

- https://github.com/ReliefApplications/ems-frontend/pull/2921

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Screenshots

Please include screenshots of this change. If this issue is only back-end related, and does not involve any visual change of the platform, you can skip this part.

# Checklist:

( \* == Mandatory )

- [ ] \* I have set myself as assignee of the pull request
- [ ] \* My code follows the style guidelines of this project
- [ ] \* Linting does not generate new warnings
- [ ] \* I have performed a self-review of my own code
- [ ] \* I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [ ] \* I have commented my code, particularly in hard-to-understand areas
- [ ] \* I have put JSDoc comment in all required places
- [ ] \* My changes generate no new warnings
- [ ] \* I have included screenshots describing my changes if relevant
- [ ] \* I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] \* New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
