### PR TITLE
AB#125619: Issue with automatic assignment deletion

### DIFF
--- a/__tests__/unit-tests/schema/mutation/editRole.mutation.spec.ts
+++ b/__tests__/unit-tests/schema/mutation/editRole.mutation.spec.ts
@@ -1,0 +1,64 @@
+import { createMongoAbility } from '@casl/ability';
+import { Role } from '@models';
+import { Context } from '@server/apollo/context';
+import editRole from '@schema/mutation/editRole.mutation';
+import { DatabaseHelpers } from '../../../helpers/database-helpers';
+
+describe('editRole Resolver', () => {
+  let databaseHelpers: DatabaseHelpers;
+  let context: Context;
+
+  beforeAll(async () => {
+    databaseHelpers = new DatabaseHelpers();
+    await databaseHelpers.connect();
+  });
+
+  afterAll(async () => {
+    await databaseHelpers.disconnect();
+  });
+
+  beforeEach(() => {
+    context = {
+      user: {
+        ability: createMongoAbility([{ action: 'update', subject: 'Role' }]),
+      },
+      i18next: { t: jest.fn((key: string) => key) },
+    } as unknown as Context;
+  });
+
+  it('removes a rule when the request contains transient query-builder controls', async () => {
+    const rule = {
+      logic: 'and',
+      filters: [
+        { field: '{{email}}', operator: 'endswith', value: '@who.int' },
+      ],
+    };
+    const role = await Role.create({
+      title: 'Guest',
+      application: '507f1f77bcf86cd799439011',
+      autoAssignment: [rule],
+    });
+
+    await editRole.resolve(
+      null,
+      {
+        id: role.id,
+        autoAssignment: {
+          remove: {
+            logic: 'and',
+            filters: [
+              {
+                ...rule.filters[0],
+                inTheLast: { number: 1, unit: 'days' },
+              },
+            ],
+          },
+        },
+      },
+      context
+    );
+
+    const savedRole = await Role.findById(role.id);
+    expect(savedRole.autoAssignment).toEqual([]);
+  });
+});

--- a/src/schema/mutation/editRole.mutation.ts
+++ b/src/schema/mutation/editRole.mutation.ts
@@ -6,7 +6,7 @@ import {
   GraphQLError,
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
-import { get, has } from 'lodash';
+import { get, has, isEqual } from 'lodash';
 import { Role } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { RoleType } from '../types';
@@ -28,6 +28,30 @@ type EditRoleArgs = {
 };
 
 /**
+ * Removes transient query-builder controls before comparing assignment rules.
+ *
+ * @param value rule value to normalize
+ * @returns normalized rule value
+ */
+const normalizeAutoAssignmentRule = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(normalizeAutoAssignmentRule);
+  }
+  if (value && typeof value === 'object') {
+    return Object.entries(value).reduce<Record<string, unknown>>(
+      (rule, [key, item]) => {
+        if (key !== 'inTheLast') {
+          rule[key] = normalizeAutoAssignmentRule(item);
+        }
+        return rule;
+      },
+      {}
+    );
+  }
+  return value;
+};
+
+/**
  * Edit a role's admin permissions, providing its id and the list of admin permissions.
  * Throw an error if not logged or authorized.
  */
@@ -43,7 +67,7 @@ export default {
       type: GraphQLJSON,
     },
   },
-  async resolve(parent, args: EditRoleArgs, context: Context) {
+  async resolve(_parent: unknown, args: EditRoleArgs, context: Context) {
     graphQLAuthCheck(context);
     try {
       const autoAssignmentUpdate: any = {};
@@ -51,14 +75,9 @@ export default {
         if (has(args.autoAssignment, 'add')) {
           Object.assign(autoAssignmentUpdate, {
             $addToSet: {
-              autoAssignment: get(args.autoAssignment, 'add'),
-            },
-          });
-        }
-        if (has(args.autoAssignment, 'remove')) {
-          Object.assign(autoAssignmentUpdate, {
-            $pull: {
-              autoAssignment: get(args.autoAssignment, 'remove'),
+              autoAssignment: normalizeAutoAssignmentRule(
+                get(args.autoAssignment, 'add')
+              ),
             },
           });
         }
@@ -71,8 +90,7 @@ export default {
         args.permissions && { permissions: args.permissions },
         args.channels && { channels: args.channels },
         args.title && { title: args.title },
-        args.description && { description: args.description },
-        autoAssignmentUpdate.$pull && { $pull: autoAssignmentUpdate.$pull }
+        args.description && { description: args.description }
       );
 
       const filters = Role.find(accessibleBy(ability, 'update').Role)
@@ -81,6 +99,27 @@ export default {
 
       // Save operations. Adding try / catch to detect duplication issues.
       try {
+        if (has(args.autoAssignment, 'remove')) {
+          const role = await Role.findOne(filters).select('autoAssignment');
+          if (!role) {
+            throw new GraphQLError(
+              context.i18next.t('common.errors.permissionNotGranted')
+            );
+          }
+          const ruleToRemove = role.autoAssignment.find((rule) =>
+            isEqual(
+              normalizeAutoAssignmentRule(rule),
+              normalizeAutoAssignmentRule(get(args.autoAssignment, 'remove'))
+            )
+          );
+          if (ruleToRemove) {
+            Object.assign(autoAssignmentUpdate, {
+              $pull: { autoAssignment: ruleToRemove },
+            });
+            Object.assign(update, { $pull: autoAssignmentUpdate.$pull });
+          }
+        }
+
         // doing a separate update to avoid the following error:
         // Updating the path 'x' would create a conflict at 'x'
         if (autoAssignmentUpdate.$addToSet) {


### PR DESCRIPTION
# Description

Automatic assignment rules could appear deleted in the UI but reappear after navigating away and back. 

The reason was that the frontend query-builder includes a transient `inTheLast` property in the deletion payload, while existing MongoDB rules may not contain it. Because MongoDB `$pull` requires an exact embedded-document match, the rule was not actually removed.

The backend now normalizes automatic-assignment rules before comparison, locates the matching stored rule, and removes that exact stored document. New rules are also normalized before persistence to prevent transient UI state from being stored. Also, automatically assigned users are derived from active rules, so once the rule is removed, users matching only that rule are no longer automatically assigned.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/125619

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added an integration test that persists an automatic-assignment rule without `inTheLast`, sends a deletion request containing the transient property, and verifies the rule is removed.
- [x] Ran linting and a TypeScript production build.

Commands run:

npx eslint src/schema/mutation/editRole.mutation.ts
npx eslint --no-ignore __tests__/unit-tests/schema/mutation/editRole.mutation.spec.ts
npm test -- --runInBand __tests__/unit-tests/schema/mutation/editRole.mutation.spec.ts
npm run build

Manual verification:
1. Open Back Office and navigate to an application’s Roles page.
2. Open a role, such as Guest.
3. Go to Automatic assignment.
4. Delete one rule while retaining another.
5. Navigate to a different role, then return to the original role.
6. Confirm the deleted rule does not reappear.
7. Confirm users matching only the deleted rule are no longer automatically assigned to the role.

## Screenshots

Not applicable. This is a backend-only fix with no visual changes.

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules