### PR TITLE
AB#103759: Search in grid on text field of resource field not working

### DIFF
--- a/__tests__/unit-tests/utils/schema/resolvers/Query/linkedRecordCalculatedFilter.integration.spec.ts
+++ b/__tests__/unit-tests/utils/schema/resolvers/Query/linkedRecordCalculatedFilter.integration.spec.ts
@@ -1,8 +1,10 @@
 import mongoose from 'mongoose';
+import { Ability } from '@casl/ability';
 import { Record, Resource } from '@models';
 import { CalculatedFieldService } from '@services/calculatedField.service';
 import getFilter from '@utils/schema/resolvers/Query/getFilter';
 import getSortAggregation from '@utils/schema/resolvers/Query/getSortAggregation';
+import all from '@utils/schema/resolvers/Query/all';
 import { DatabaseHelpers } from '../../../../../helpers/database-helpers';
 
 let databaseHelpers: DatabaseHelpers;
@@ -170,6 +172,49 @@ describe('filtering on a linked record calculated field, as the records query do
         value: 'France',
       })
     ).toEqual(['t1', 't2']);
+  });
+
+  it('filters linked text columns through the records grid resolver', async () => {
+    const queryTeams = all(
+      'team',
+      { team: team.fields, country: country.fields },
+      { team: team._id, country: country._id }
+    );
+    const context = {
+      user: {
+        _id: new mongoose.Types.ObjectId(),
+        ability: new Ability([{ action: 'manage', subject: 'all' }]),
+      },
+      i18next: { t: (key: string) => key },
+    };
+    const info = { fieldNodes: [] };
+
+    for (const [operator, value] of [
+      ['contains', 'Fran'],
+      ['eq', 'France'],
+    ]) {
+      const result = await queryTeams(
+        null,
+        {
+          sortField: undefined,
+          first: 10,
+          skip: 0,
+          afterCursor: undefined,
+          at: undefined,
+          filter: {
+            logic: 'and',
+            filters: [{ field: 'country.name', operator, value }],
+          },
+        },
+        context,
+        info
+      );
+
+      expect(result.edges.map((edge) => edge.node.data.label)).toEqual([
+        't1',
+        't2',
+      ]);
+    }
   });
 
   it('filters on a calculated field of the linked record', async () => {


### PR DESCRIPTION
# Description

The current backend implementation already supports this behavior. 

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/103759/

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- [x] `npm run test -- __tests__/unit-tests/utils/schema/resolvers/Query/linkedRecordCalculatedFilter.integration.spec.ts`
- [x] `npm run lint`
- [x] `npm run build`

The integration test creates Country and Team resources, links team records to country records, then invokes the same dynamic resolver used by grid widgets. It asserts that `contains` and `eq` filters on `country.name` return only the teams linked to France.

## Screenshots

Not applicable. This is backend regression coverage with no visual platform changes.

# Checklist:

( * == Mandatory )

- [ ] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules