### PR TITLE
AB#135743 Allow sorting query layouts by more than one field

### DIFF
--- a/__tests__/unit-tests/utils/schema/resolvers/Query/getSortAggregation.spec.ts
+++ b/__tests__/unit-tests/utils/schema/resolvers/Query/getSortAggregation.spec.ts
@@ -20,9 +20,11 @@ describe('getSortAggregation - localized choice sort', () => {
     mockedGetFullChoices.mockResolvedValue(CHOICES);
     const fields = [{ name: 'status', type: 'dropdown', choices: CHOICES }];
 
-    const aggregation = await getSortAggregation('status', 'asc', fields, {
-      locale: 'uk',
-    });
+    const aggregation = await getSortAggregation(
+      [{ field: 'status', order: 'asc' }],
+      fields,
+      { locale: 'uk' }
+    );
 
     const addFields = aggregation.find((s) => s.$addFields);
     // The choices text array injected into the pipeline must be translated.
@@ -40,9 +42,11 @@ describe('getSortAggregation - localized choice sort', () => {
     mockedGetFullChoices.mockResolvedValue(CHOICES);
     const fields = [{ name: 'status', type: 'tagbox', choices: CHOICES }];
 
-    const aggregation = await getSortAggregation('status', 'desc', fields, {
-      locale: 'uk',
-    });
+    const aggregation = await getSortAggregation(
+      [{ field: 'status', order: 'desc' }],
+      fields,
+      { locale: 'uk' }
+    );
 
     const addFields = aggregation.find((s) => s.$addFields);
     const injectedChoices = addFields.$addFields._status.$let.vars.choices;
@@ -56,14 +60,103 @@ describe('getSortAggregation - localized choice sort', () => {
     mockedGetFullChoices.mockResolvedValue(CHOICES);
     const fields = [{ name: 'status', type: 'dropdown', choices: CHOICES }];
 
-    const aggregation = await getSortAggregation('status', 'asc', fields, {
-      locale: 'fr',
-    });
+    const aggregation = await getSortAggregation(
+      [{ field: 'status', order: 'asc' }],
+      fields,
+      { locale: 'fr' }
+    );
 
     const addFields = aggregation.find((s) => s.$addFields);
     expect(addFields.$addFields._status.$let.vars.choicesText).toEqual([
       'New',
       'Closed',
     ]);
+  });
+});
+
+describe('getSortAggregation - compound sort', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns an empty aggregation when no descriptors are given', async () => {
+    const aggregation = await getSortAggregation([], [], {});
+    expect(aggregation).toEqual([]);
+  });
+
+  it('sorts by several plain fields, preserving priority order', async () => {
+    const fields = [
+      { name: 'priority_flag', type: 'text' },
+      { name: 'lastname', type: 'text' },
+    ];
+
+    const aggregation = await getSortAggregation(
+      [
+        { field: 'priority_flag', order: 'asc' },
+        { field: 'lastname', order: 'desc' },
+      ],
+      fields,
+      {}
+    );
+
+    expect(aggregation).toEqual([
+      {
+        $sort: {
+          'data.priority_flag': 1,
+          'data.lastname': -1,
+        },
+      },
+    ]);
+  });
+
+  it('combines a choice field and a plain field without collisions', async () => {
+    mockedGetFullChoices.mockResolvedValue(CHOICES);
+    const fields = [
+      { name: 'status', type: 'dropdown', choices: CHOICES },
+      { name: 'lastname', type: 'text' },
+    ];
+
+    const aggregation = await getSortAggregation(
+      [
+        { field: 'status', order: 'asc' },
+        { field: 'lastname', order: 'asc' },
+      ],
+      fields,
+      {}
+    );
+
+    // Only the choice field should produce an $addFields stage.
+    const addFieldsStages = aggregation.filter((s) => s.$addFields);
+    expect(addFieldsStages).toHaveLength(1);
+    expect(addFieldsStages[0].$addFields._status).toBeDefined();
+
+    // The trailing $sort stage should reference both resolved paths, in order.
+    expect(aggregation[aggregation.length - 1]).toEqual({
+      $sort: { _status: 1, 'data.lastname': 1 },
+    });
+  });
+
+  it('handles two choice fields without key collisions', async () => {
+    mockedGetFullChoices.mockResolvedValue(CHOICES);
+    const fields = [
+      { name: 'status', type: 'dropdown', choices: CHOICES },
+      { name: 'severity', type: 'dropdown', choices: CHOICES },
+    ];
+
+    const aggregation = await getSortAggregation(
+      [
+        { field: 'status', order: 'asc' },
+        { field: 'severity', order: 'desc' },
+      ],
+      fields,
+      {}
+    );
+
+    const addFieldsStages = aggregation.filter((s) => s.$addFields);
+    expect(addFieldsStages).toHaveLength(2);
+    expect(addFieldsStages[0].$addFields._status).toBeDefined();
+    expect(addFieldsStages[1].$addFields._severity).toBeDefined();
+
+    expect(aggregation[aggregation.length - 1]).toEqual({
+      $sort: { _status: 1, _severity: -1 },
+    });
   });
 });

--- a/__tests__/unit-tests/utils/schema/resolvers/Query/linkedRecordCalculatedFilter.integration.spec.ts
+++ b/__tests__/unit-tests/utils/schema/resolvers/Query/linkedRecordCalculatedFilter.integration.spec.ts
@@ -3,6 +3,7 @@ import { Record, Resource } from '@models';
 import { CalculatedFieldService } from '@services/calculatedField.service';
 import getFilter from '@utils/schema/resolvers/Query/getFilter';
 import getSortAggregation from '@utils/schema/resolvers/Query/getSortAggregation';
+import normalizeSortDescriptors from '@utils/schema/resolvers/Query/normalizeSortDescriptors';
 import { DatabaseHelpers } from '../../../../../helpers/database-helpers';
 
 let databaseHelpers: DatabaseHelpers;
@@ -106,7 +107,11 @@ describe('filtering on a linked record calculated field, as the records query do
       ...(await buildLinkedRecordsAggregation(usedSubFields)),
       { $match: mongooseFilter },
       ...(sort
-        ? await getSortAggregation(sort[0], sort[1], fields, context)
+        ? await getSortAggregation(
+            normalizeSortDescriptors(sort[0], sort[1]),
+            fields,
+            context
+          )
         : [{ $sort: { incrementalId: 1 } }]),
     ]);
     return results.map((r: any) => r.data.label);

--- a/__tests__/unit-tests/utils/schema/resolvers/Query/normalizeSortDescriptors.spec.ts
+++ b/__tests__/unit-tests/utils/schema/resolvers/Query/normalizeSortDescriptors.spec.ts
@@ -1,0 +1,58 @@
+import normalizeSortDescriptors from '@utils/schema/resolvers/Query/normalizeSortDescriptors';
+
+describe('normalizeSortDescriptors', () => {
+  it('returns an empty array when nothing is provided', () => {
+    expect(normalizeSortDescriptors()).toEqual([]);
+  });
+
+  it('falls back to sortField/sortOrder when sortFields is absent', () => {
+    expect(normalizeSortDescriptors('lastname', 'desc')).toEqual([
+      { field: 'lastname', order: 'desc' },
+    ]);
+  });
+
+  it('defaults sortOrder to asc when omitted', () => {
+    expect(normalizeSortDescriptors('lastname')).toEqual([
+      { field: 'lastname', order: 'asc' },
+    ]);
+  });
+
+  it('prefers sortFields over sortField/sortOrder when non-empty', () => {
+    const result = normalizeSortDescriptors('lastname', 'desc', [
+      { field: 'priority_flag', order: 'asc' },
+      { field: 'lastUpdatedDate', order: 'asc' },
+      { field: 'lastname', order: 'asc' },
+    ]);
+    expect(result).toEqual([
+      { field: 'priority_flag', order: 'asc' },
+      { field: 'lastUpdatedDate', order: 'asc' },
+      { field: 'lastname', order: 'asc' },
+    ]);
+  });
+
+  it('falls back to sortField/sortOrder when sortFields is an empty array', () => {
+    expect(normalizeSortDescriptors('lastname', 'asc', [])).toEqual([
+      { field: 'lastname', order: 'asc' },
+    ]);
+  });
+
+  it('filters out entries without a field name', () => {
+    const result = normalizeSortDescriptors(undefined, undefined, [
+      { field: 'priority_flag', order: 'asc' },
+      { field: '', order: 'asc' },
+      undefined as any,
+    ]);
+    expect(result).toEqual([{ field: 'priority_flag', order: 'asc' }]);
+  });
+
+  it('defaults an invalid or missing order to asc', () => {
+    const result = normalizeSortDescriptors(undefined, undefined, [
+      { field: 'priority_flag' },
+      { field: 'lastname', order: 'invalid' as any },
+    ]);
+    expect(result).toEqual([
+      { field: 'priority_flag', order: 'asc' },
+      { field: 'lastname', order: 'asc' },
+    ]);
+  });
+});

--- a/src/routes/download/index.ts
+++ b/src/routes/download/index.ts
@@ -341,6 +341,7 @@ router.get('/resource/records/:id', async (req, res) => {
  *    query: any                          // Query parameters to build it
  *    sortField?: string
  *    sortOrder?: 'asc' | 'desc'
+ *    sortFields?: { field: string, order?: 'asc' | 'desc' }[]  // takes precedence over sortField/sortOrder when non-empty
  * }
  */
 router.post('/records', async (req, res) => {

--- a/src/utils/files/resourceExporter.ts
+++ b/src/utils/files/resourceExporter.ts
@@ -21,6 +21,7 @@ import { Response } from 'express';
 import extendAbilityForRecords from '@security/extendAbilityForRecords';
 import { accessibleBy } from '@casl/mongoose';
 import getSortAggregation from '@utils/schema/resolvers/Query/getSortAggregation';
+import normalizeSortDescriptors from '@utils/schema/resolvers/Query/normalizeSortDescriptors';
 import dataSources from '@server/apollo/dataSources';
 import sanitizeHtml from 'sanitize-html';
 import { getErrorMessage } from '@utils/error';
@@ -35,6 +36,7 @@ interface ExportBatchParams {
   query: any;
   sortField?: string;
   sortOrder?: 'asc' | 'desc';
+  sortFields?: { field: string; order?: string }[];
   resource?: string;
   timeZone: string;
   fileName?: string;
@@ -294,8 +296,11 @@ export default class Exporter {
       set(this.req.context, 'accesstoken', this.req.headers.accesstoken);
     }
     const sort = await getSortAggregation(
-      this.params.sortField,
-      this.params.sortOrder,
+      normalizeSortDescriptors(
+        this.params.sortField,
+        this.params.sortOrder,
+        this.params.sortFields
+      ),
       this.resource.fields,
       this.req.context
     );

--- a/src/utils/schema/introspection/getSchema.ts
+++ b/src/utils/schema/introspection/getSchema.ts
@@ -140,6 +140,11 @@ export const getSchema = (
             skip: { type: GraphQLInt },
             sortField: { type: GraphQLString },
             sortOrder: { type: GraphQLString },
+            // Array of { field: string, order: 'asc' | 'desc' }, takes
+            // precedence over sortField/sortOrder when non-empty, enabling
+            // compound (multi-field) sorting while keeping single-field
+            // callers working unchanged.
+            sortFields: { type: GraphQLJSON },
             filter: { type: GraphQLJSON },
             display: { type: GraphQLBoolean },
             styles: { type: GraphQLJSON },

--- a/src/utils/schema/resolvers/Query/all.ts
+++ b/src/utils/schema/resolvers/Query/all.ts
@@ -10,6 +10,7 @@ import getFilter, {
 } from './getFilter';
 import getStyle from './getStyle';
 import getSortAggregation from './getSortAggregation';
+import normalizeSortDescriptors from './normalizeSortDescriptors';
 import mongoose from 'mongoose';
 import buildReferenceDataAggregation from '@utils/aggregation/buildReferenceDataAggregation';
 import { getAccessibleFields } from '@utils/form';
@@ -222,6 +223,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
     {
       sortField,
       sortOrder = 'asc',
+      sortFields,
       first = DEFAULT_FIRST,
       skip = 0,
       afterCursor,
@@ -250,11 +252,18 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
         context.display = true;
       }
 
+      // Normalize legacy sortField/sortOrder and the new sortFields array
+      // into a single ordered list of sort descriptors (sortFields wins when
+      // non-empty), so single- and multi-field sort share the same pipeline.
+      const sortDescriptors = normalizeSortDescriptors(
+        sortField,
+        sortOrder,
+        sortFields
+      );
+
       // === FILTERING ===
       const usedFields = extractFilterFields(filter);
-      if (sortField) {
-        usedFields.push(sortField);
-      }
+      sortDescriptors.forEach((s) => usedFields.push(s.field));
 
       // Get list of needed resources for the aggregation
       const resourcesToQuery = [
@@ -391,7 +400,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
       // when the query sorts, filters, styles or actions on it
       const isNeededBeforeFilters = (field: any) => {
         // If sort field is a calculated field
-        if (sortField === field.name) return true;
+        if (sortDescriptors.some((s) => s.field === field.name)) return true;
 
         // Check if the field is used in the filter
         if (isUsedInFilter(filter, field.name)) return true;
@@ -487,12 +496,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
 
       // If we're using skip parameter, include them into the aggregation
       if (skip || skip === 0) {
-        const sort = await getSortAggregation(
-          sortField,
-          sortOrder,
-          fields,
-          context
-        );
+        const sort = await getSortAggregation(sortDescriptors, fields, context);
         // When neither the query filter nor the permission filters reference
         // a calculated field, filter before computing calculated fields, so
         // that expensive stages (e.g. related-record lookups, when sorting by
@@ -552,12 +556,7 @@ export default (entityName: string, fieldsByName: any, idsByName: any) =>
           {
             $facet: {
               results: [
-                ...(await getSortAggregation(
-                  sortField,
-                  sortOrder,
-                  fields,
-                  context
-                )),
+                ...(await getSortAggregation(sortDescriptors, fields, context)),
                 { $limit: first + 1 },
               ],
               totalCount: [

--- a/src/utils/schema/resolvers/Query/getSortAggregation.ts
+++ b/src/utils/schema/resolvers/Query/getSortAggregation.ts
@@ -1,24 +1,29 @@
+import { SortOrder } from 'mongoose';
 import { MULTISELECT_TYPES } from '@const/fieldTypes';
 import { getFullChoices } from '../../../form';
 import getSortField from './getSortField';
 import getSortOrder from './getSortOrder';
 import getTranslatedFieldName from './getTranslatedFieldName';
 import { resolveLocalizedString } from '@utils/i18n/resolveLocalizedString';
+import { SortDescriptor } from './normalizeSortDescriptors';
 
 /**
- * Builds sort aggregation.
+ * Builds the aggregation stages (choice-resolution + sort) for a single sort
+ * descriptor, and adds its resolved path/order to the shared sort stage.
  *
  * @param sortField Sort by field
  * @param sortOrder Sort order
  * @param fields Structure fields
  * @param context Request context
- * @returns Sort aggregation
+ * @param sortStage Shared compound $sort object, mutated in place
+ * @returns Aggregation stages needed before the $sort stage (e.g. $addFields for choice resolution)
  */
-const getSortAggregation = async (
+const buildSortDescriptorAggregation = async (
   sortField: string,
   sortOrder: string,
   fields: any[],
-  context: any
+  context: any,
+  sortStage: Record<string, SortOrder>
 ): Promise<any[]> => {
   // Locale-based translation: replace the sort field with its sibling
   // translation field when one matches the user's locale.
@@ -118,13 +123,47 @@ const getSortAggregation = async (
       });
     }
   }
-  // Add the sort step to the aggregation
-  aggregation.push({
-    $sort: {
-      [`${getSortField(sortField, parentField ? parentField : field)}`]:
-        getSortOrder(sortOrder),
-    },
-  });
+  // Add this field's resolved path/order to the shared compound sort stage
+  sortStage[getSortField(sortField, parentField ? parentField : field)] =
+    getSortOrder(sortOrder);
+  return aggregation;
+};
+
+/**
+ * Builds sort aggregation for one or several sort descriptors, applied in
+ * priority order (equivalent to a SQL `ORDER BY field1, field2, ...`).
+ *
+ * @param sortDescriptors Ordered list of sort descriptors to apply
+ * @param fields Structure fields
+ * @param context Request context
+ * @returns Sort aggregation
+ */
+const getSortAggregation = async (
+  sortDescriptors: SortDescriptor[],
+  fields: any[],
+  context: any
+): Promise<any[]> => {
+  if (!sortDescriptors || sortDescriptors.length === 0) {
+    return [];
+  }
+
+  const aggregation: any[] = [];
+  // Plain object: key insertion order gives us the sort priority order for
+  // MongoDB's compound $sort stage.
+  const sortStage: Record<string, SortOrder> = {};
+
+  for (const descriptor of sortDescriptors) {
+    const stages = await buildSortDescriptorAggregation(
+      descriptor.field,
+      descriptor.order,
+      fields,
+      context,
+      sortStage
+    );
+    aggregation.push(...stages);
+  }
+
+  aggregation.push({ $sort: sortStage });
   return aggregation;
 };
 

--- a/src/utils/schema/resolvers/Query/normalizeSortDescriptors.ts
+++ b/src/utils/schema/resolvers/Query/normalizeSortDescriptors.ts
@@ -1,0 +1,35 @@
+/** A single sort descriptor: logical field name + direction. */
+export interface SortDescriptor {
+  field: string;
+  order: 'asc' | 'desc';
+}
+
+/**
+ * Normalizes the legacy sortField/sortOrder scalars and the new sortFields
+ * array into a single ordered list of sort descriptors. sortFields wins when
+ * present and non-empty; otherwise falls back to sortField/sortOrder, so
+ * callers that only know about the legacy scalars keep working unchanged.
+ *
+ * @param sortField Legacy single sort field name
+ * @param sortOrder Legacy single sort order
+ * @param sortFields Ordered list of { field, order } sort descriptors
+ * @returns Normalized, ordered list of sort descriptors
+ */
+export default (
+  sortField?: string,
+  sortOrder?: string,
+  sortFields?: { field: string; order?: string }[]
+): SortDescriptor[] => {
+  if (Array.isArray(sortFields) && sortFields.length > 0) {
+    return sortFields
+      .filter((s) => s && s.field)
+      .map((s) => ({
+        field: s.field,
+        order: s.order === 'desc' ? 'desc' : ('asc' as const),
+      }));
+  }
+  if (sortField) {
+    return [{ field: sortField, order: sortOrder === 'desc' ? 'desc' : 'asc' }];
+  }
+  return [];
+};


### PR DESCRIPTION
# Description

Added the possibility to add multiple sorting fields to a grid layout, you have a button to add more field lines on the sort tab. Fields can be reordered.

## Useful links

- [135743 ABC - Allow sorting of query layouts by more than one field](https://dev.azure.com/WHOHQ/EMSSAFE/_boards/board/t/App%20Builder%20-%20Core/Stories?System.IterationPath=@currentIteration&workitem=135743)
- [Frontend PR](https://github.com/ReliefApplications/ems-frontend/pull/2925)

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Create a grid layout, go to sorting, add multiple fields.
- [x] Make sure single and previous layout sorting still works.

## Screenshots

<img width="1026" height="688" alt="Screenshot 2026-08-14 at 12 27 51" src="https://github.com/user-attachments/assets/6ef32c26-017b-43c4-bf0d-8b886149046b" />

# Checklist:

( * == Mandatory ) 

- [x] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# More explanation
https://www.loom.com/share/05a716d61b9744faaf51fb304c21d1e5?sid=f87cf896-582a-4f76-93ae-8ceed801b145
