### PR TITLE
AB#109751: Prevent import of incorrect data

### DIFF
--- a/__tests__/unit-tests/routes/upload/upload.routes.spec.ts
+++ b/__tests__/unit-tests/routes/upload/upload.routes.spec.ts
@@ -1,0 +1,83 @@
+import { Form, Record } from '@models';
+import uploadRoutes from '@routes/upload';
+import { Workbook } from 'exceljs';
+import express, { NextFunction, Request, Response } from 'express';
+import fileUpload from 'express-fileupload';
+import mongoose from 'mongoose';
+import supertest from 'supertest';
+import { DatabaseHelpers } from '../../../helpers/database-helpers';
+
+jest.mock('@services/logger.service');
+
+/** Test user with permission to upload records. */
+const user = {
+  _id: new mongoose.Types.ObjectId(),
+  ability: {
+    can: () => true,
+  },
+  name: 'Test user',
+  roles: [],
+  username: 'test.user',
+};
+
+/**
+ * Build a minimal application with upload authentication context.
+ *
+ * @returns Express application
+ */
+const buildApp = () => {
+  const app = express();
+  app.use(fileUpload());
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    (req as Request & { context: { user: typeof user } }).context = { user };
+    next();
+  });
+  app.use('/upload', uploadRoutes);
+  return app;
+};
+
+/** Build a valid XLSX buffer with one invalid resource reference. */
+const buildInvalidResourceImport = async (): Promise<Buffer> => {
+  const workbook = new Workbook();
+  const worksheet = workbook.addWorksheet('Records');
+  worksheet.addRow(['linkedRecord']);
+  worksheet.addRow(['not-a-resource-id']);
+  return Buffer.from(await workbook.xlsx.writeBuffer());
+};
+
+let databaseHelpers: DatabaseHelpers;
+let request: supertest.SuperTest<supertest.Test>;
+let form: Form;
+
+describe('Upload routes', () => {
+  beforeAll(async () => {
+    databaseHelpers = new DatabaseHelpers();
+    await databaseHelpers.connect();
+    request = supertest(buildApp());
+    form = await Form.create({
+      fields: [
+        {
+          name: 'linkedRecord',
+          resource: new mongoose.Types.ObjectId(),
+          type: 'resource',
+        },
+      ],
+      graphQLTypeName: 'ImportedRecords',
+      name: 'Imported records',
+      structure: { pages: [] },
+    });
+  });
+
+  afterAll(async () => {
+    await databaseHelpers.disconnect();
+  });
+
+  it('rejects imports containing an invalid resource reference', async () => {
+    const response = await request
+      .post(`/upload/form/records/${form.id}`)
+      .attach('excelFile', await buildInvalidResourceImport(), 'records.xlsx');
+
+    expect(response.status).toBe(400);
+    await expect(Record.countDocuments({ form: form._id })).resolves.toBe(0);
+  });
+});

--- a/__tests__/unit-tests/utils/form/transformRecord.spec.ts
+++ b/__tests__/unit-tests/utils/form/transformRecord.spec.ts
@@ -1,4 +1,8 @@
-import { formatValue, transformRecord } from '@utils/form/transformRecord';
+import {
+  formatValue,
+  getInvalidResourceField,
+  transformRecord,
+} from '@utils/form/transformRecord';
 
 describe('formatValue', () => {
   it('converts date-like fields to Date objects', () => {
@@ -41,16 +45,46 @@ describe('formatValue', () => {
     expect(formatValue({ type: 'resource' }, 'aaaaaaaaaaaa')).toBeNull();
   });
 
+  it('drops malformed resource ids without throwing', () => {
+    expect(formatValue({ type: 'resource' }, 'not-a-resource-id')).toBeNull();
+  });
+
   it('filters invalid ids out of resources arrays', () => {
     const validId = '507f1f77bcf86cd799439011';
-    expect(formatValue({ type: 'resources' }, [validId, 'aaaaaaaaaaaa'])).toEqual(
-      [validId]
-    );
+    expect(
+      formatValue({ type: 'resources' }, [validId, 'aaaaaaaaaaaa'])
+    ).toEqual([validId]);
   });
 
   it('returns unchanged values for unknown field types', () => {
     expect(formatValue({ type: 'boolean' }, true)).toBe(true);
     expect(formatValue({ type: 'numeric' }, 42)).toBe(42);
+  });
+});
+
+describe('getInvalidResourceField', () => {
+  const fields = [
+    { name: 'linkedRecord', type: 'resource' },
+    { name: 'description', type: 'text' },
+  ];
+
+  it('returns the resource field with an invalid record id', () => {
+    expect(
+      getInvalidResourceField({ linkedRecord: 'not-a-resource-id' }, fields)
+    ).toBe('linkedRecord');
+  });
+
+  it('accepts empty and valid resource values', () => {
+    expect(getInvalidResourceField({}, fields)).toBeUndefined();
+    expect(
+      getInvalidResourceField({ linkedRecord: '' }, fields)
+    ).toBeUndefined();
+    expect(
+      getInvalidResourceField(
+        { linkedRecord: '507f1f77bcf86cd799439011' },
+        fields
+      )
+    ).toBeUndefined();
   });
 });
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -345,6 +345,7 @@
 		},
 		"upload": {
 			"errors": {
+				"invalidResourceReference": "The value for resource field {{field}} must be a valid record identifier.",
 				"invalidUserUpload": "Please provide email and role for each user.",
 				"missingFile": "No file detected.",
 				"noRecordsToInsert": "No records were provided for insertion."

--- a/src/i18n/test.json
+++ b/src/i18n/test.json
@@ -345,6 +345,7 @@
 		},
 		"upload": {
 			"errors": {
+				"invalidResourceReference": "****** {{field}} ******",
 				"invalidUserUpload": "******",
 				"missingFile": "******",
 				"noRecordsToInsert": "******"

--- a/src/i18n/uk.json
+++ b/src/i18n/uk.json
@@ -345,6 +345,7 @@
 		},
 		"upload": {
 			"errors": {
+				"invalidResourceReference": "Значення поля ресурсу {{field}} має бути дійсним ідентифікатором запису.",
 				"invalidUserUpload": "Будь ласка, вкажіть email та Роль для кожного користувача.",
 				"missingFile": "Файл не виявлено.",
 				"noRecordsToInsert": "Не було надано записів для вставки."

--- a/src/routes/upload/index.ts
+++ b/src/routes/upload/index.ts
@@ -11,7 +11,7 @@ import {
 } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { getUploadColumns, loadRow, uploadFile } from '@utils/files';
-import { getNextId } from '@utils/form';
+import { getInvalidResourceField, getNextId } from '@utils/form';
 import i18next from 'i18next';
 import get from 'lodash/get';
 import { logger } from '@services/logger.service';
@@ -101,6 +101,17 @@ async function insertRecords(
     const structureId = String(
       form.resource ? get(form.resource, '_id', form.resource) : form.id
     );
+    const invalidDataSet = dataSets.find((dataSet) =>
+      getInvalidResourceField(dataSet.data, fields)
+    );
+    if (invalidDataSet) {
+      return res.status(400).send(
+        i18next.t('routes.upload.errors.invalidResourceReference', {
+          field: getInvalidResourceField(invalidDataSet.data, fields),
+        })
+      );
+    }
+
     // Create records one by one so the incrementalId works correctly
     for (const dataSet of dataSets) {
       records.push(

--- a/src/utils/form/transformRecord.ts
+++ b/src/utils/form/transformRecord.ts
@@ -3,6 +3,42 @@ import { getDateForMongo } from '../filter/getDateForMongo';
 import { getTimeForMongo } from '../filter/getTimeForMongo';
 import isNil from 'lodash/isNil';
 
+type FieldDefinition = {
+  name: string;
+  type: string;
+};
+
+/**
+ * Check whether a value is a canonical MongoDB ObjectId string.
+ *
+ * @param value candidate resource record identifier
+ * @returns whether the value can safely be used as a resource record id
+ */
+export const isValidResourceId = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  mongoose.isValidObjectId(value) &&
+  new mongoose.Types.ObjectId(value).toString() === value;
+
+/**
+ * Get the resource field containing an invalid imported record identifier.
+ *
+ * @param record imported record data
+ * @param fields form or resource field definitions
+ * @returns invalid resource field name, if any
+ */
+export const getInvalidResourceField = (
+  record: Record<string, unknown>,
+  fields: FieldDefinition[]
+): string | undefined =>
+  fields.find(
+    (field) =>
+      field.type === 'resource' &&
+      record[field.name] !== undefined &&
+      record[field.name] !== null &&
+      record[field.name] !== '' &&
+      !isValidResourceId(record[field.name])
+  )?.name;
+
 /**
  * Format passed value to comply with field definition.
  *
@@ -45,20 +81,14 @@ export const formatValue = (field: any, value: any): any => {
       break;
     case 'resource':
       if (!isNil(value)) {
-        //checks if the id is a valid mongo id
-        return new mongoose.Types.ObjectId(value).toString() === value
-          ? value
-          : null;
+        return isValidResourceId(value) ? value : null;
       }
       break;
 
     case 'resources':
       if (!isNil(value) && Array.isArray(value)) {
         //returns only valid ids from an array of ids
-        return value.filter(
-          (resourceId) =>
-            new mongoose.Types.ObjectId(resourceId).toString() === resourceId
-        );
+        return value.filter((resourceId) => isValidResourceId(resourceId));
       }
       break;
     case 'people-dropdown':


### PR DESCRIPTION
# Description

Prevents malformed values in `resource` question columns from being imported. Previously, invalid resource identifiers could be stored and later cause record-grid queries to fail. The backend now rejects the complete XLSX import with a clear validation response before creating records. The frontend now displays that server response in the upload snackbar instead of the generic upload error.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/109751/

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Backend import validation test
  - Upload an XLSX file containing `not-a-resource-id` in a `resource` field column.
  - Verify the API returns HTTP 400.
  - Verify no records are created.

- Frontend upload-notification test
  - Simulate the HTTP interceptor's transformed `Error`.
  - Verify the upload snackbar displays the backend validation message.

- Shared frontend unit-test suite
  - `npx nx run shared:test:ci --runInBand`
  - Result: 24 suites and 342 tests passing.

- Shared frontend lint
  - `npx nx run shared:lint --output-style=static`

- Backend targeted tests and validation
  - `npm run test -- __tests__/unit-tests/routes/upload/upload.routes.spec.ts __tests__/unit-tests/utils/form/transformRecord.spec.ts --runInBand`
  - `npm run build`
  - `npm run check-i18n`

Manual verification:
1. Open `Dashboard > Resources > [resource] > Records`.
2. Upload an XLSX file with an invalid value in a `resource` question column.
3. Verify the snackbar displays the server validation message, for example: `The value for resource field members must be a valid record identifier.`
4. Verify the records grid remains unchanged.

## Screenshots

When trying to upload an invalid id for a Resource field:

<img width="630" height="175" alt="image" src="https://github.com/user-attachments/assets/dc10627a-c0e0-4389-9af0-99a67638e1a7" />

# Checklist:

- [ ] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules