### PR TITLE
AB#82962: The data for map popouts should be loaded on demand, not upfront

### DIFF
--- a/src/routes/gis/index.ts
+++ b/src/routes/gis/index.ts
@@ -11,12 +11,88 @@ import i18next from 'i18next';
 import mongoose from 'mongoose';
 import { logger } from '@services/logger.service';
 import axios from 'axios';
-import { isEqual, get, omit, isEmpty } from 'lodash';
+import { isEqual, get, omit, isEmpty, pick } from 'lodash';
 import turf, { Feature, booleanPointInPolygon } from '@turf/turf';
 import { CustomAPI, buildDataSource } from '@server/apollo/dataSources';
 import { getAdmin0Polygons } from '@utils/gis/getCountryPolygons';
 import filterReferenceData from '@utils/referenceData/referenceDataFilter.util';
 import { getErrorMessage, getErrorStack } from '@utils/error';
+import redis from '@server/redis';
+import { v4 as uuidv4 } from 'uuid';
+
+/** Redis key prefix for popup feature collections. */
+const POPUP_CACHE_PREFIX = 'gis:popup:';
+/** Lifetime for cached popup feature collections. */
+const POPUP_CACHE_TTL_SECONDS = 15 * 60;
+/** Internal property sent with compact map features. */
+const POPUP_REFERENCE_FIELD = '__oortPopup';
+
+type PopupReference = {
+  cacheKey: string;
+  featureIndex: number;
+};
+
+type PopupCacheEntry = {
+  features: Feature[];
+  popupFields: string[];
+  owner: string;
+};
+
+type PopupRequest = {
+  cacheKey?: string;
+  featureIndexes?: number[];
+};
+
+/**
+ * Cache complete feature properties and return the key used by popup lookups.
+ *
+ * @param features Complete features generated for a map layer.
+ * @param popupFields Fields required by the configured popup.
+ * @param owner User that can retrieve the cached feature data.
+ * @returns Cache key when Redis is available, otherwise undefined.
+ */
+const cachePopupFeatures = async (
+  features: Feature[],
+  popupFields: string[],
+  owner: string
+) => {
+  try {
+    const client = await redis();
+    if (!client) {
+      return undefined;
+    }
+    const cacheKey = `${POPUP_CACHE_PREFIX}${uuidv4()}`;
+    const cacheEntry: PopupCacheEntry = { features, popupFields, owner };
+    await client.set(cacheKey, JSON.stringify(cacheEntry), {
+      EX: POPUP_CACHE_TTL_SECONDS,
+    });
+    return cacheKey;
+  } catch (err) {
+    logger.error(`Failed to cache GIS popup data: ${getErrorMessage(err)}`);
+    return undefined;
+  }
+};
+
+/**
+ * Replace popup-only properties with a reference to their server-side cache.
+ *
+ * @param features Complete features generated for a map layer.
+ * @param cacheKey Key for the complete feature collection in Redis.
+ * @param displayFields Fields required to render the layer before a popup opens.
+ * @returns Compact features for the initial map response.
+ */
+const compactFeaturesForMap = (
+  features: Feature[],
+  cacheKey: string,
+  displayFields: string[]
+) =>
+  features.map((feature, featureIndex) => ({
+    ...feature,
+    properties: {
+      ...pick(feature.properties || {}, displayFields),
+      [POPUP_REFERENCE_FIELD]: { cacheKey, featureIndex } as PopupReference,
+    },
+  }));
 
 /**
  * Endpoint for custom feature layers
@@ -229,6 +305,48 @@ const gqlQuery = (
   });
 
 /**
+ * Get complete properties for features from a cached map layer.
+ */
+router.post('/feature/popup', async (req, res) => {
+  const { cacheKey, featureIndexes } = req.body as PopupRequest;
+  if (
+    typeof cacheKey !== 'string' ||
+    !Array.isArray(featureIndexes) ||
+    featureIndexes.some(
+      (featureIndex) => !Number.isInteger(featureIndex) || featureIndex < 0
+    )
+  ) {
+    return res.status(400).send(i18next.t('common.errors.dataNotFound'));
+  }
+
+  try {
+    const client = await redis();
+    const cacheData = client ? await client.get(cacheKey) : null;
+    if (!cacheData) {
+      return res.status(404).send(i18next.t('common.errors.dataNotFound'));
+    }
+
+    const cacheEntry = JSON.parse(cacheData) as PopupCacheEntry;
+    if (cacheEntry.owner !== req.context.user._id.toString()) {
+      return res.status(404).send(i18next.t('common.errors.dataNotFound'));
+    }
+    const features = featureIndexes
+      .map((featureIndex) => cacheEntry.features[featureIndex])
+      .filter((feature): feature is Feature => Boolean(feature))
+      .map((feature) => ({
+        ...feature,
+        properties: pick(feature.properties || {}, cacheEntry.popupFields),
+      }));
+    return res.send({ features });
+  } catch (err) {
+    logger.error(getErrorMessage(err), { stack: getErrorStack(err) });
+    return res
+      .status(500)
+      .send(i18next.t('routes.gis.feature.errors.unexpected'));
+  }
+});
+
+/**
  * Build endpoint
  *
  * @param req current http request
@@ -250,6 +368,13 @@ router.post('/feature', async (req, res) => {
     const contextFilters = JSON.parse(get(req, 'body.contextFilters', null));
     const queryParams = JSON.parse(get(req, 'body.queryParams', null));
     const at = get(req, 'body.at') as string | undefined;
+    const hasPopupData = get(req, 'body.hasPopupData', false) === true;
+    const popupFields = get(req, 'body.popupFields', []).filter(
+      (field: unknown): field is string => typeof field === 'string'
+    );
+    const displayFields = get(req, 'body.displayFields', []).filter(
+      (field: unknown): field is string => typeof field === 'string'
+    );
     if (!geoField && !(latitudeField && longitudeField)) {
       return res
         .status(400)
@@ -427,6 +552,20 @@ router.post('/feature', async (req, res) => {
       }
     } else {
       return res.status(404).send(i18next.t('common.errors.dataNotFound'));
+    }
+    if (hasPopupData) {
+      const cacheKey = await cachePopupFeatures(
+        featureCollection.features,
+        popupFields,
+        req.context.user._id.toString()
+      );
+      if (cacheKey) {
+        featureCollection.features = compactFeaturesForMap(
+          featureCollection.features,
+          cacheKey,
+          displayFields
+        );
+      }
     }
     return res.send(featureCollection);
   } catch (err) {


### PR DESCRIPTION
# Description

Improves map popup performance by loading popup data on demand instead of including it in the initial map-layer response.

The backend now caches the complete generated feature layer in Redis for 15 minutes and returns compact features containing only display data and an internal popup reference. When a user clicks a marker or cluster, the frontend requests only that feature's configured popup fields from the cache. Cache entries are scoped to the authenticated user. The implementation also preserves admin geometry mappings, supports popup template placeholders, and ignores stale popup responses from rapid consecutive clicks.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/82962/

## Type of change

- [x] Improvement (refactor or addition to existing functionality)

# How Has This Been Tested?

- Backend build and lint
  - Run `npm run build` in `ems-backend`.
  - Run `npx eslint "src/routes/gis/index.ts"` in `ems-backend`.

- Frontend lint and unit tests
  - Run `npx nx run shared:lint --output-style=static` in `ems-frontend`.
  - Run `npx nx run shared:test --configuration=ci --runInBand` in `ems-frontend`.
  - Result: 24 test suites and 343 tests passed.

- Manual Front Office verification
  1. Open `/{applicationId}/dashboard/{dashboardId}` for **Health Emergencies Management Suite – TEST**.
  2. Load the **Dashboard** map and inspect `POST /gis/feature`.
  3. Confirm the initial response includes only compact features and `__oortPopup`, without popup fields.
  4. Click a marker or cluster.
  5. Confirm `POST /gis/feature/popup` is sent.
  6. Confirm the popup displays the fields returned by the popup request.
  7. Confirm the initial GIS layer request is not repeated when opening popups.

## Screenshots

Not applicable. This is a performance and network-payload improvement with no intended visual change.

# Checklist:

- [ ] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [ ] * I have put the ticket for review, adding the oort-frontend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [ ] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
