### PR TITLE
AB#137417: Allow resource & resources fields during upload to use object IDs

### DIFF
--- a/__tests__/unit-tests/utils/form/normalizeUploadedResourceFields.spec.ts
+++ b/__tests__/unit-tests/utils/form/normalizeUploadedResourceFields.spec.ts
@@ -1,0 +1,81 @@
+import { Record } from '@models';
+import { normalizeUploadedResourceFields } from '@utils/form/normalizeUploadedResourceFields';
+import mongoose from 'mongoose';
+
+/** Resource configured on the relationship fields. */
+const linkedResourceId = new mongoose.Types.ObjectId();
+/** Different resource used to verify resource-scoped validation. */
+const otherResourceId = new mongoose.Types.ObjectId();
+/** Existing record in the linked resource. */
+const validRecordId = new mongoose.Types.ObjectId();
+/** Second existing record in the linked resource. */
+const anotherValidRecordId = new mongoose.Types.ObjectId();
+
+describe('normalizeUploadedResourceFields', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('converts a valid record ID from the linked resource to an ObjectId', async () => {
+    const distinct = jest
+      .spyOn(Record, 'distinct')
+      .mockResolvedValue([validRecordId.toString()]);
+    const data = { linkedRecord: validRecordId.toString() };
+
+    await normalizeUploadedResourceFields(data, [
+      { name: 'linkedRecord', type: 'resource', resource: linkedResourceId },
+    ]);
+
+    expect(data.linkedRecord).toEqual(validRecordId);
+    expect(distinct).toHaveBeenCalledWith('_id', {
+      _id: { $in: [validRecordId.toString()] },
+      resource: linkedResourceId,
+    });
+  });
+
+  it('removes malformed and unlinked single-resource IDs', async () => {
+    const distinct = jest.spyOn(Record, 'distinct');
+    const data = {
+      malformed: 'not-an-object-id',
+      unlinked: validRecordId.toString(),
+    };
+    distinct.mockResolvedValueOnce([]);
+
+    await normalizeUploadedResourceFields(data, [
+      { name: 'malformed', type: 'resource', resource: linkedResourceId },
+      { name: 'unlinked', type: 'resource', resource: otherResourceId },
+    ]);
+
+    expect(data).toEqual({});
+    expect(distinct).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps only valid linked IDs from semicolon-separated resource lists', async () => {
+    jest
+      .spyOn(Record, 'distinct')
+      .mockResolvedValue([
+        validRecordId.toString(),
+        anotherValidRecordId.toString(),
+      ]);
+    const data = {
+      linkedRecords: `${validRecordId}; not-an-object-id; ${anotherValidRecordId}; ${new mongoose.Types.ObjectId()}`,
+    };
+
+    await normalizeUploadedResourceFields(data, [
+      { name: 'linkedRecords', type: 'resources', resource: linkedResourceId },
+    ]);
+
+    expect(data.linkedRecords).toEqual([validRecordId, anotherValidRecordId]);
+  });
+
+  it('removes resource lists when none of their IDs belong to the linked resource', async () => {
+    jest.spyOn(Record, 'distinct').mockResolvedValue([]);
+    const data = { linkedRecords: `${validRecordId};${anotherValidRecordId}` };
+
+    await normalizeUploadedResourceFields(data, [
+      { name: 'linkedRecords', type: 'resources', resource: linkedResourceId },
+    ]);
+
+    expect(data).toEqual({});
+  });
+});

--- a/src/routes/upload/index.ts
+++ b/src/routes/upload/index.ts
@@ -11,7 +11,7 @@ import {
 } from '@models';
 import { AppAbility } from '@security/defineUserAbility';
 import { getUploadColumns, loadRow, uploadFile } from '@utils/files';
-import { getNextId } from '@utils/form';
+import { getNextId, normalizeUploadedResourceFields } from '@utils/form';
 import i18next from 'i18next';
 import get from 'lodash/get';
 import { logger } from '@services/logger.service';
@@ -103,6 +103,7 @@ async function insertRecords(
     );
     // Create records one by one so the incrementalId works correctly
     for (const dataSet of dataSets) {
+      await normalizeUploadedResourceFields(dataSet.data, fields);
       records.push(
         new Record({
           incrementalId: await getNextId(structureId),
@@ -136,7 +137,7 @@ async function insertRecords(
     }
     if (records.length > 0) {
       try {
-        Record.insertMany(records);
+        await Record.insertMany(records);
         return res.status(200).send({ status: 'OK' });
       } catch (err) {
         logger.error(getErrorMessage(err), { stack: getErrorStack(err) });

--- a/src/utils/form/index.ts
+++ b/src/utils/form/index.ts
@@ -9,6 +9,7 @@ export * from './hasInaccessibleFields';
 
 // === RECORDS ===
 export * from './transformRecord';
+export * from './normalizeUploadedResourceFields';
 export * from './getOwnership';
 export * from './getNextId';
 export * from './getDisplayText';

--- a/src/utils/form/normalizeUploadedResourceFields.ts
+++ b/src/utils/form/normalizeUploadedResourceFields.ts
@@ -1,0 +1,76 @@
+import { Record } from '@models';
+import mongoose from 'mongoose';
+
+type ResourceField = {
+  name: string;
+  type: string;
+  resource?: mongoose.Types.ObjectId | string;
+};
+
+type RecordData = { [key: string]: unknown };
+
+/**
+ * Checks whether a string is a canonical MongoDB ObjectId.
+ *
+ * @param value potential MongoDB ObjectId.
+ * @returns whether the value is a canonical MongoDB ObjectId.
+ */
+const isMongoId = (value: string): boolean =>
+  mongoose.isObjectIdOrHexString(value) &&
+  new mongoose.Types.ObjectId(value).toString() === value;
+
+/**
+ * Converts uploaded resource record IDs to ObjectIds after confirming that
+ * they belong to the resource configured for each relationship field.
+ *
+ * @param data uploaded record data.
+ * @param fields fields declared on the uploaded form or resource.
+ */
+export const normalizeUploadedResourceFields = async (
+  data: RecordData,
+  fields: ResourceField[]
+): Promise<void> => {
+  for (const field of fields) {
+    if (
+      (field.type !== 'resource' && field.type !== 'resources') ||
+      !Object.prototype.hasOwnProperty.call(data, field.name)
+    ) {
+      continue;
+    }
+
+    const value = data[field.name];
+    const ids =
+      field.type === 'resources' && typeof value === 'string'
+        ? value.split(';').map((id) => id.trim())
+        : typeof value === 'string'
+        ? [value.trim()]
+        : [];
+    const validIds = ids.filter(isMongoId);
+
+    if (!field.resource || validIds.length === 0) {
+      delete data[field.name];
+      continue;
+    }
+
+    const matchingIds = await Record.distinct('_id', {
+      _id: { $in: validIds },
+      resource: field.resource,
+    });
+    const matchingIdSet = new Set(matchingIds.map(String));
+    const resourceIds = validIds
+      .filter((id) => matchingIdSet.has(id))
+      .map((id) => new mongoose.Types.ObjectId(id));
+
+    if (field.type === 'resource') {
+      if (resourceIds.length > 0) {
+        data[field.name] = resourceIds[0];
+      } else {
+        delete data[field.name];
+      }
+    } else if (resourceIds.length > 0) {
+      data[field.name] = resourceIds;
+    } else {
+      delete data[field.name];
+    }
+  }
+};


### PR DESCRIPTION
# Description

Adds support for MongoDB record IDs in uploaded resource and resources fields.

During XLSX uploads:
- Valid canonical MongoDB IDs are verified against the resource configured on the field.
- Valid IDs are stored as ObjectId values, activating record links.
- Invalid, malformed, or wrong-resource IDs are removed.
- resources fields accept semicolon-separated IDs and retain valid entries when others are invalid.
- Record insertion is awaited so insertion failures are handled correctly.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/137417

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Unit tests for uploaded resource ID normalization
- ESLint and TypeScript build

Commands run:
- ```npx eslint src/routes/upload/index.ts src/utils/form/normalizeUploadedResourceFields.ts src/utils/form/index.ts __tests__/unit-tests/utils/form/normalizeUploadedResourceFields.spec.ts --ext .ts --no-ignore```
- ```npm run test -- __tests__/unit-tests/utils/form/normalizeUploadedResourceFields.spec.ts```
- ```npm run build```

Unit tests cover:
- Valid single-resource IDs
- Malformed IDs
- IDs belonging to a different resource
- Semicolon-separated multi-resource IDs with mixed valid and invalid values
- Multi-resource values with no valid linked records

## Screenshots

N/A, backend-only change.

# Checklist:

( * == Mandatory ) 

- [ ] * I have set myself as assignee of the pull request
- [x] * My code follows the style guidelines of this project
- [x] * Linting does not generate new warnings
- [x] * I have performed a self-review of my own code
- [x] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [x] * I have commented my code, particularly in hard-to-understand areas
- [x] * I have put JSDoc comment in all required places
- [x] * My changes generate no new warnings
- [x] * I have included screenshots describing my changes if relevant
- [x] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules