### PR TITLE
AB#137461: ABC - Search issue with 129867

### DIFF
--- a/__tests__/unit-tests/utils/schema/resolvers/Query/getFilter.spec.ts
+++ b/__tests__/unit-tests/utils/schema/resolvers/Query/getFilter.spec.ts
@@ -6,7 +6,12 @@ import getFilter, {
 /** Fields of the queried resource */
 const FIELDS = [
   { name: 'title', type: 'text' },
-  { name: 'title_en', type: 'text', translateField: 'title', translateTo: 'en' },
+  {
+    name: 'title_en',
+    type: 'text',
+    translateField: 'title',
+    translateTo: 'en',
+  },
   { name: 'count', type: 'numeric' },
   { name: 'status', type: 'dropdown', choices: [] },
   { name: 'tags', type: 'tagbox', choices: [] },
@@ -40,6 +45,26 @@ const globalSearch = (rules: any[]) => ({
   logic: 'and',
   filters: [
     { logic: 'or', field: '_globalSearch', operator: 'contains', value: rules },
+  ],
+});
+
+/**
+ * Expected shape of a rule applied to the displayed value of a translated
+ * field: the translation sibling when set, otherwise the source field.
+ *
+ * @param translated path of the translation sibling
+ * @param source path of the source field
+ * @param build builds the rule for a given field path
+ * @returns expected mongo filter
+ */
+const displayedValue = (
+  translated: string,
+  source: string,
+  build: (name: string) => any
+) => ({
+  $or: [
+    { $and: [{ [translated]: { $nin: [null, ''] } }, build(translated)] },
+    { $and: [{ [translated]: { $in: [null, ''] } }, build(source)] },
   ],
 });
 
@@ -102,10 +127,7 @@ describe('getFilter - global search expansion', () => {
       { 'data.title': { $regex: 'cholera', $options: 'i' } },
       // numeric eq matches both string and number storage
       {
-        $or: [
-          { 'data.count': { $eq: '12' } },
-          { 'data.count': { $eq: 12 } },
-        ],
+        $or: [{ 'data.count': { $eq: '12' } }, { 'data.count': { $eq: 12 } }],
       },
       { 'data.tags': { $all: ['cholera'] } },
     ]);
@@ -137,26 +159,12 @@ describe('getFilter - global search expansion', () => {
     ]);
     // Locale with a translation sibling on the related resource
     const result = getFilter(filter, FIELDS, { ...CONTEXT, locale: 'pt' });
-    expect(result.$and[0].$or[0].$expr.$regexMatch).toMatchObject({
-      regex: 'colera',
-      options: 'i',
-    });
-    expect(
-      result.$and[0].$or[0].$expr.$regexMatch.input.$convert.input.$cond
-    ).toEqual([
-      {
-        $or: [
-          {
-            $in: [
-              { $type: '$_emergency.data.name_pt' },
-              ['missing', 'null'],
-            ],
-          },
-          { $eq: ['$_emergency.data.name_pt', ''] },
-        ],
-      },
-      '$_emergency.data.name',
-      '$_emergency.data.name_pt',
+    expect(result.$and[0].$or).toEqual([
+      displayedValue(
+        '_emergency.data.name_pt',
+        '_emergency.data.name',
+        (name) => ({ [name]: { $regex: 'colera', $options: 'i' } })
+      ),
     ]);
     // Locale without a sibling falls back to the source subfield
     const fallback = getFilter(filter, FIELDS, { ...CONTEXT, locale: 'fr' });
@@ -170,54 +178,22 @@ describe('getFilter - global search expansion', () => {
       { field: 'title', operator: 'contains', value: 'Коваленко' },
     ]);
     const result = getFilter(filter, FIELDS, { ...CONTEXT, locale: 'en' });
-    const regexMatch = result.$and[0].$or[0].$expr.$regexMatch;
-
-    expect(regexMatch).toMatchObject({
-      regex: 'Коваленко',
-      options: 'i',
-    });
-    expect(regexMatch.input.$convert.input.$cond).toEqual([
-      {
-        $or: [
-          { $in: [{ $type: '$data.title_en' }, ['missing', 'null']] },
-          { $eq: ['$data.title_en', ''] },
-        ],
-      },
-      '$data.title',
-      '$data.title_en',
+    expect(result.$and[0].$or).toEqual([
+      displayedValue('data.title_en', 'data.title', (name) => ({
+        [name]: { $regex: 'Коваленко', $options: 'i' },
+      })),
     ]);
   });
 
-  it('keeps regular contains filters scoped to the translated field', () => {
-    const direct = getFilter(
-      {
-        logic: 'and',
-        filters: [{ field: 'title', operator: 'contains', value: 'patient' }],
-      },
-      FIELDS,
-      { ...CONTEXT, locale: 'en' }
-    );
-    expect(direct).toEqual({
-      $and: [{ 'data.title_en': { $regex: 'patient', $options: 'i' } }],
-    });
-
-    const related = getFilter(
-      {
-        logic: 'and',
-        filters: [
-          { field: 'emergency.name', operator: 'contains', value: 'colera' },
-        ],
-      },
-      FIELDS,
-      { ...CONTEXT, locale: 'pt' }
-    );
-    expect(related).toEqual({
-      $and: [
-        {
-          '_emergency.data.name_pt': { $regex: 'colera', $options: 'i' },
-        },
-      ],
-    });
+  it('does not drop translated rules from the global search expansion', () => {
+    // The `$in: [null, '']` used to detect an empty translation must not be
+    // mistaken for a failed date parse
+    const filter = globalSearch([
+      { field: 'title', operator: 'contains', value: 'patient' },
+    ]);
+    const result = getFilter(filter, FIELDS, { ...CONTEXT, locale: 'en' });
+    expect(result.$and[0].$or).toHaveLength(1);
+    expect(result.$and[0]).not.toEqual(MATCH_NOTHING);
   });
 
   it('supports in operator for choice values matched by display text', () => {
@@ -241,7 +217,7 @@ describe('getFilter - global search expansion', () => {
       { 'data.title': { $regex: '\\(test', $options: 'i' } },
     ]);
     // the escaped pattern must be a valid regex matching the literal string
-    const pattern = result.$and[0].$or[0]["data.title"].$regex;
+    const pattern = result.$and[0].$or[0]['data.title'].$regex;
     expect(new RegExp(pattern).test('a (test b')).toBe(true);
   });
 
@@ -336,6 +312,161 @@ describe('getFilter - global search expansion', () => {
   });
 });
 
+describe('getFilter - filters on translated text fields', () => {
+  const direct = (rule: any, locale: string) =>
+    getFilter({ logic: 'and', filters: [rule] }, FIELDS, {
+      ...CONTEXT,
+      locale,
+    });
+
+  it('applies contains to the displayed value', () => {
+    const result = direct(
+      { field: 'title', operator: 'contains', value: 'patient' },
+      'en'
+    );
+    expect(result).toEqual({
+      $and: [
+        displayedValue('data.title_en', 'data.title', (name) => ({
+          [name]: { $regex: 'patient', $options: 'i' },
+        })),
+      ],
+    });
+  });
+
+  it('applies eq / neq to the displayed value', () => {
+    const eq = direct(
+      { field: 'title', operator: 'eq', value: 'Cholera' },
+      'en'
+    );
+    expect(eq).toEqual({
+      $and: [
+        displayedValue('data.title_en', 'data.title', (name) => ({
+          [name]: { $eq: 'Cholera' },
+        })),
+      ],
+    });
+    const neq = direct(
+      { field: 'title', operator: 'neq', value: 'Cholera' },
+      'en'
+    );
+    expect(neq).toEqual({
+      $and: [
+        displayedValue('data.title_en', 'data.title', (name) => ({
+          [name]: { $ne: 'Cholera' },
+        })),
+      ],
+    });
+  });
+
+  it('applies startswith / endswith / doesnotcontain to the displayed value', () => {
+    const startsWith = direct(
+      { field: 'title', operator: 'startswith', value: 'Cho' },
+      'en'
+    );
+    expect(startsWith).toEqual({
+      $and: [
+        displayedValue('data.title_en', 'data.title', (name) => ({
+          [name]: { $regex: '^Cho', $options: 'i' },
+        })),
+      ],
+    });
+    const endsWith = direct(
+      { field: 'title', operator: 'endswith', value: 'era' },
+      'en'
+    );
+    expect(endsWith).toEqual({
+      $and: [
+        displayedValue('data.title_en', 'data.title', (name) => ({
+          [name]: { $regex: 'era$', $options: 'i' },
+        })),
+      ],
+    });
+    const doesNotContain = direct(
+      { field: 'title', operator: 'doesnotcontain', value: 'era' },
+      'en'
+    );
+    expect(doesNotContain).toEqual({
+      $and: [
+        displayedValue('data.title_en', 'data.title', (name) => ({
+          [name]: { $not: { $regex: 'era', $options: 'i' } },
+        })),
+      ],
+    });
+  });
+
+  it('applies isempty / isnotempty / isnull / isnotnull to the displayed value', () => {
+    const isEmpty = direct({ field: 'title', operator: 'isempty' }, 'en');
+    expect(isEmpty).toEqual({
+      $and: [
+        displayedValue('data.title_en', 'data.title', (name) => ({
+          [name]: { $exists: true, $eq: '' },
+        })),
+      ],
+    });
+    const isNotEmpty = direct({ field: 'title', operator: 'isnotempty' }, 'en');
+    expect(isNotEmpty).toEqual({
+      $and: [
+        displayedValue('data.title_en', 'data.title', (name) => ({
+          [name]: { $exists: true, $nin: [null, ''] },
+        })),
+      ],
+    });
+    const isNull = direct({ field: 'title', operator: 'isnull' }, 'en');
+    expect(isNull).toEqual({
+      $and: [
+        displayedValue('data.title_en', 'data.title', (name) => ({
+          $or: [{ [name]: { $exists: false } }, { [name]: { $eq: null } }],
+        })),
+      ],
+    });
+    const isNotNull = direct({ field: 'title', operator: 'isnotnull' }, 'en');
+    expect(isNotNull).toEqual({
+      $and: [
+        displayedValue('data.title_en', 'data.title', (name) => ({
+          [name]: { $exists: true, $ne: null },
+        })),
+      ],
+    });
+  });
+
+  it('applies rules on related-resource subfields to the displayed value', () => {
+    const result = direct(
+      { field: 'emergency.name', operator: 'contains', value: 'colera' },
+      'pt'
+    );
+    expect(result).toEqual({
+      $and: [
+        displayedValue(
+          '_emergency.data.name_pt',
+          '_emergency.data.name',
+          (name) => ({ [name]: { $regex: 'colera', $options: 'i' } })
+        ),
+      ],
+    });
+  });
+
+  it('leaves fields untouched when no sibling matches the locale', () => {
+    const result = direct(
+      { field: 'title', operator: 'contains', value: 'patient' },
+      'fr'
+    );
+    expect(result).toEqual({
+      $and: [{ 'data.title': { $regex: 'patient', $options: 'i' } }],
+    });
+    const noLocale = getFilter(
+      {
+        logic: 'and',
+        filters: [{ field: 'title', operator: 'contains', value: 'patient' }],
+      },
+      FIELDS,
+      CONTEXT
+    );
+    expect(noLocale).toEqual({
+      $and: [{ 'data.title': { $regex: 'patient', $options: 'i' } }],
+    });
+  });
+});
+
 describe('getFilter - isempty / isnotempty operators', () => {
   it('isnotempty on a tagbox field excludes null values and empty arrays', () => {
     const result = getFilter(
@@ -405,7 +536,11 @@ describe('getFilter - user attribute & people current-user filters', () => {
     const filter = {
       logic: 'and',
       filters: [
-        { field: '$attribute.country.iso3code', operator: 'eq', value: 'title' },
+        {
+          field: '$attribute.country.iso3code',
+          operator: 'eq',
+          value: 'title',
+        },
       ],
     };
     const result = getFilter(filter, FIELDS, USER_CONTEXT);
@@ -415,9 +550,7 @@ describe('getFilter - user attribute & people current-user filters', () => {
   it('matches nothing when an attribute filter has no user in context', () => {
     const filter = {
       logic: 'and',
-      filters: [
-        { field: '$attribute.region', operator: 'eq', value: 'title' },
-      ],
+      filters: [{ field: '$attribute.region', operator: 'eq', value: 'title' }],
     };
     const result = getFilter(filter, FIELDS, CONTEXT);
     expect(result).toEqual({ $and: [MATCH_NOTHING] });
@@ -511,8 +644,12 @@ describe('getFilter - user attribute & people current-user filters', () => {
           $and: [
             {
               $or: [
-                { 'data.focal_point.firstname': { $regex: 'me', $options: 'i' } },
-                { 'data.focal_point.lastname': { $regex: 'me', $options: 'i' } },
+                {
+                  'data.focal_point.firstname': { $regex: 'me', $options: 'i' },
+                },
+                {
+                  'data.focal_point.lastname': { $regex: 'me', $options: 'i' },
+                },
                 {
                   'data.focal_point.emailaddress': {
                     $regex: 'me',
@@ -542,7 +679,9 @@ describe('getFilter - attribute field comparisons robustness', () => {
     const inResult = getFilter(
       {
         logic: 'and',
-        filters: [{ field: '$attribute.region', operator: 'in', value: 'title' }],
+        filters: [
+          { field: '$attribute.region', operator: 'in', value: 'title' },
+        ],
       },
       FIELDS,
       USER_CONTEXT
@@ -562,9 +701,7 @@ describe('getFilter - attribute field comparisons robustness', () => {
       USER_CONTEXT
     );
     expect(notinResult).toEqual({
-      $and: [
-        { 'data.title': { $not: { $regex: '^EURO$', $options: 'i' } } },
-      ],
+      $and: [{ 'data.title': { $not: { $regex: '^EURO$', $options: 'i' } } }],
     });
   });
 
@@ -575,9 +712,7 @@ describe('getFilter - attribute field comparisons robustness', () => {
     };
     const rule = (operator: string) => ({
       logic: 'and',
-      filters: [
-        { field: '$attribute.region.id', operator, value: 'tags' },
-      ],
+      filters: [{ field: '$attribute.region.id', operator, value: 'tags' }],
     });
 
     // record stores e.g. tags: [4, 3, 5] (numbers) or ['4'] (strings)
@@ -604,10 +739,7 @@ describe('getFilter - attribute field comparisons robustness', () => {
     expect(getFilter(rule('eq'), FIELDS, numericContext)).toEqual({
       $and: [
         {
-          $or: [
-            { 'data.tags': { $eq: '4' } },
-            { 'data.tags': { $eq: 4 } },
-          ],
+          $or: [{ 'data.tags': { $eq: '4' } }, { 'data.tags': { $eq: 4 } }],
         },
       ],
     });
@@ -634,15 +766,15 @@ describe('getFilter - attribute field comparisons robustness', () => {
     const result = getFilter(
       {
         logic: 'and',
-        filters: [{ field: '$attribute.region', operator: 'in', value: 'title' }],
+        filters: [
+          { field: '$attribute.region', operator: 'in', value: 'title' },
+        ],
       },
       FIELDS,
       { ...CONTEXT, user: { attributes: { region: 'EURO (west)' } } }
     );
     expect(result).toEqual({
-      $and: [
-        { 'data.title': { $regex: '^EURO \\(west\\)$', $options: 'i' } },
-      ],
+      $and: [{ 'data.title': { $regex: '^EURO \\(west\\)$', $options: 'i' } }],
     });
   });
 });

--- a/__tests__/unit-tests/utils/schema/resolvers/Query/getFilter.spec.ts
+++ b/__tests__/unit-tests/utils/schema/resolvers/Query/getFilter.spec.ts
@@ -6,6 +6,7 @@ import getFilter, {
 /** Fields of the queried resource */
 const FIELDS = [
   { name: 'title', type: 'text' },
+  { name: 'title_en', type: 'text', translateField: 'title', translateTo: 'en' },
   { name: 'count', type: 'numeric' },
   { name: 'status', type: 'dropdown', choices: [] },
   { name: 'tags', type: 'tagbox', choices: [] },
@@ -136,14 +137,87 @@ describe('getFilter - global search expansion', () => {
     ]);
     // Locale with a translation sibling on the related resource
     const result = getFilter(filter, FIELDS, { ...CONTEXT, locale: 'pt' });
-    expect(result.$and[0].$or).toEqual([
-      { '_emergency.data.name_pt': { $regex: 'colera', $options: 'i' } },
+    expect(result.$and[0].$or[0].$expr.$regexMatch).toMatchObject({
+      regex: 'colera',
+      options: 'i',
+    });
+    expect(
+      result.$and[0].$or[0].$expr.$regexMatch.input.$convert.input.$cond
+    ).toEqual([
+      {
+        $or: [
+          {
+            $in: [
+              { $type: '$_emergency.data.name_pt' },
+              ['missing', 'null'],
+            ],
+          },
+          { $eq: ['$_emergency.data.name_pt', ''] },
+        ],
+      },
+      '$_emergency.data.name',
+      '$_emergency.data.name_pt',
     ]);
     // Locale without a sibling falls back to the source subfield
     const fallback = getFilter(filter, FIELDS, { ...CONTEXT, locale: 'fr' });
     expect(fallback.$and[0].$or).toEqual([
       { '_emergency.data.name': { $regex: 'colera', $options: 'i' } },
     ]);
+  });
+
+  it('searches the displayed source value when a translation is empty', () => {
+    const filter = globalSearch([
+      { field: 'title', operator: 'contains', value: 'Коваленко' },
+    ]);
+    const result = getFilter(filter, FIELDS, { ...CONTEXT, locale: 'en' });
+    const regexMatch = result.$and[0].$or[0].$expr.$regexMatch;
+
+    expect(regexMatch).toMatchObject({
+      regex: 'Коваленко',
+      options: 'i',
+    });
+    expect(regexMatch.input.$convert.input.$cond).toEqual([
+      {
+        $or: [
+          { $in: [{ $type: '$data.title_en' }, ['missing', 'null']] },
+          { $eq: ['$data.title_en', ''] },
+        ],
+      },
+      '$data.title',
+      '$data.title_en',
+    ]);
+  });
+
+  it('keeps regular contains filters scoped to the translated field', () => {
+    const direct = getFilter(
+      {
+        logic: 'and',
+        filters: [{ field: 'title', operator: 'contains', value: 'patient' }],
+      },
+      FIELDS,
+      { ...CONTEXT, locale: 'en' }
+    );
+    expect(direct).toEqual({
+      $and: [{ 'data.title_en': { $regex: 'patient', $options: 'i' } }],
+    });
+
+    const related = getFilter(
+      {
+        logic: 'and',
+        filters: [
+          { field: 'emergency.name', operator: 'contains', value: 'colera' },
+        ],
+      },
+      FIELDS,
+      { ...CONTEXT, locale: 'pt' }
+    );
+    expect(related).toEqual({
+      $and: [
+        {
+          '_emergency.data.name_pt': { $regex: 'colera', $options: 'i' },
+        },
+      ],
+    });
   });
 
   it('supports in operator for choice values matched by display text', () => {

--- a/__tests__/unit-tests/utils/schema/resolvers/Query/getSortAggregation.spec.ts
+++ b/__tests__/unit-tests/utils/schema/resolvers/Query/getSortAggregation.spec.ts
@@ -160,3 +160,115 @@ describe('getSortAggregation - compound sort', () => {
     });
   });
 });
+
+describe('getSortAggregation - translated text fields', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  const FIELDS = [
+    { name: 'title', type: 'text' },
+    {
+      name: 'title_en',
+      type: 'text',
+      translateField: 'title',
+      translateTo: 'en',
+    },
+    { name: 'emergency', type: 'resource', resource: 'emergencyResourceId' },
+  ];
+  const EMERGENCY_FIELDS = [
+    { name: 'name', type: 'text' },
+    {
+      name: 'name_pt',
+      type: 'text',
+      translateField: 'name',
+      translateTo: 'pt',
+    },
+  ];
+  const CONTEXT = {
+    resourceFieldsById: { emergencyResourceId: EMERGENCY_FIELDS },
+  };
+
+  /**
+   * Expected displayed value expression for a translated field.
+   *
+   * @param translated path of the translation sibling
+   * @param source path of the source field
+   * @returns expected $cond expression
+   */
+  const displayedValue = (translated: string, source: string) => ({
+    $cond: [
+      {
+        $or: [
+          { $in: [{ $type: `$${translated}` }, ['missing', 'null']] },
+          { $eq: [`$${translated}`, ''] },
+        ],
+      },
+      `$${source}`,
+      `$${translated}`,
+    ],
+  });
+
+  it('sorts on the translation, falling back to the source when empty', async () => {
+    const aggregation = await getSortAggregation(
+      [{ field: 'title', order: 'asc' }],
+      FIELDS,
+      { ...CONTEXT, locale: 'en' }
+    );
+    expect(aggregation).toEqual([
+      {
+        $addFields: {
+          _title_en: displayedValue('data.title_en', 'data.title'),
+        },
+      },
+      { $sort: { _title_en: 1 } },
+    ]);
+  });
+
+  it('sorts on the source field when no sibling matches the locale', async () => {
+    const aggregation = await getSortAggregation(
+      [{ field: 'title', order: 'desc' }],
+      FIELDS,
+      { ...CONTEXT, locale: 'fr' }
+    );
+    expect(aggregation).toEqual([{ $sort: { 'data.title': -1 } }]);
+  });
+
+  it('resolves translation siblings of related-resource subfields', async () => {
+    const aggregation = await getSortAggregation(
+      [{ field: 'emergency.name', order: 'asc' }],
+      FIELDS,
+      { ...CONTEXT, locale: 'pt' }
+    );
+    expect(aggregation).toEqual([
+      {
+        $addFields: {
+          _emergency_name_pt: displayedValue(
+            '_emergency.data.name_pt',
+            '_emergency.data.name'
+          ),
+        },
+      },
+      { $sort: { _emergency_name_pt: 1 } },
+    ]);
+
+    const fallback = await getSortAggregation(
+      [{ field: 'emergency.name', order: 'asc' }],
+      FIELDS,
+      { ...CONTEXT, locale: 'fr' }
+    );
+    expect(fallback).toEqual([{ $sort: { '_emergency.data.name': 1 } }]);
+  });
+
+  it('combines a translated field with other sort fields in priority order', async () => {
+    const aggregation = await getSortAggregation(
+      [
+        { field: 'title', order: 'asc' },
+        { field: 'createdAt', order: 'desc' },
+      ],
+      FIELDS,
+      { ...CONTEXT, locale: 'en' }
+    );
+    expect(aggregation[aggregation.length - 1]).toEqual({
+      $sort: { _title_en: 1, createdAt: -1 },
+    });
+  });
+});

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -282,17 +282,21 @@ const buildAttributeFieldComparison = (
  * @param fields list of structure fields
  * @param context request context
  * @param prefix prefix to access field
+ * @param isGlobalSearch whether the rule belongs to a global-search expansion
  * @returns Mongo filter.
  */
 const buildMongoFilter = (
   filter: any,
   fields: any[],
   context: any,
-  prefix = ''
+  prefix = '',
+  isGlobalSearch = false
 ): any => {
   if (filter.filters) {
     const filters = filter.filters
-      .map((x: any) => buildMongoFilter(x, fields, context, prefix))
+      .map((x: any) =>
+        buildMongoFilter(x, fields, context, prefix, isGlobalSearch)
+      )
       .filter((x) => x);
     if (filters.length > 0) {
       switch (filter.logic) {
@@ -323,6 +327,12 @@ const buildMongoFilter = (
       let fieldName = FLAT_DEFAULT_FIELDS.includes(targetField)
         ? targetField
         : `${prefix}${targetField}`;
+      let fallbackFieldName =
+        targetField !== filter.field
+          ? FLAT_DEFAULT_FIELDS.includes(filter.field)
+            ? filter.field
+            : `${prefix}${filter.field}`
+          : undefined;
       // Get type of field from filter field
       let type: string =
         fields.find(
@@ -473,6 +483,10 @@ const buildMongoFilter = (
                 context?.locale
               );
               fieldName = `_${resourceName}.data.${translatedSubField}`;
+              fallbackFieldName =
+                translatedSubField !== subFieldName
+                  ? `_${resourceName}.data.${subFieldName}`
+                  : undefined;
             }
           }
         }
@@ -739,7 +753,8 @@ const buildMongoFilter = (
                     },
                     fields,
                     context,
-                    prefix
+                    prefix,
+                    true
                   )
                 )
                 .filter((x: any) => x && !containsNullComparison(x));
@@ -749,6 +764,47 @@ const buildMongoFilter = (
                 return MATCH_NOTHING;
               }
               return { $or: subFilters };
+            } else if (
+              isGlobalSearch &&
+              fallbackFieldName &&
+              typeof value === 'string'
+            ) {
+              // Entity resolvers display the source value when the localized
+              // sibling is missing, null or empty. Apply the regex to that
+              // same per-record value so global search matches what is shown.
+              const translatedValue = `$${fieldName}`;
+              return {
+                $expr: {
+                  $regexMatch: {
+                    input: {
+                      $convert: {
+                        input: {
+                          $cond: [
+                            {
+                              $or: [
+                                {
+                                  $in: [
+                                    { $type: translatedValue },
+                                    ['missing', 'null'],
+                                  ],
+                                },
+                                { $eq: [translatedValue, ''] },
+                              ],
+                            },
+                            `$${fallbackFieldName}`,
+                            translatedValue,
+                          ],
+                        },
+                        to: 'string',
+                        onError: '',
+                        onNull: '',
+                      },
+                    },
+                    regex: value,
+                    options: 'i',
+                  },
+                },
+              };
             } else if (PEOPLE_TYPES.includes(type)) {
               // People fields store the person object(s) — search the name /
               // email subfields the widgets display. Multi-word searches

--- a/src/utils/schema/resolvers/Query/getFilter.ts
+++ b/src/utils/schema/resolvers/Query/getFilter.ts
@@ -111,6 +111,11 @@ const containsNullComparison = (filter: any): boolean => {
     ) {
       return true;
     }
+    // Explicit value lists (e.g. `$in: [null, '']` used to detect an empty
+    // translation) are intentional and never come from a failed date parse
+    if (['$in', '$nin', '$all'].includes(key)) {
+      continue;
+    }
     if (containsNullComparison(val)) {
       return true;
     }
@@ -276,27 +281,56 @@ const buildAttributeFieldComparison = (
 };
 
 /**
+ * Applies a rule to the value the entity resolvers display for a translated
+ * field: the translation sibling when it is set, otherwise the source field.
+ *
+ * The two branches are mutually exclusive, so the rule (including negative
+ * operators such as notequal / doesnotcontain / isnull) is evaluated on
+ * exactly one field per record, the one that is shown to the user.
+ *
+ * @param translatedField path of the translation sibling
+ * @param sourceField path of the source field
+ * @param build builds the rule for a given field path
+ * @returns Mongo filter matching the rule on the displayed value
+ */
+const withTranslationFallback = (
+  translatedField: string,
+  sourceField: string,
+  build: (fieldName: string) => any
+): any => {
+  const translatedFilter = build(translatedField);
+  const sourceFilter = build(sourceField);
+  if (!translatedFilter || !sourceFilter) {
+    return translatedFilter;
+  }
+  return {
+    $or: [
+      {
+        $and: [{ [translatedField]: { $nin: [null, ''] } }, translatedFilter],
+      },
+      { $and: [{ [translatedField]: { $in: [null, ''] } }, sourceFilter] },
+    ],
+  };
+};
+
+/**
  * Transforms query filter into mongo filter.
  *
  * @param filter filter to transform to mongo filter.
  * @param fields list of structure fields
  * @param context request context
  * @param prefix prefix to access field
- * @param isGlobalSearch whether the rule belongs to a global-search expansion
  * @returns Mongo filter.
  */
 const buildMongoFilter = (
   filter: any,
   fields: any[],
   context: any,
-  prefix = '',
-  isGlobalSearch = false
+  prefix = ''
 ): any => {
   if (filter.filters) {
     const filters = filter.filters
-      .map((x: any) =>
-        buildMongoFilter(x, fields, context, prefix, isGlobalSearch)
-      )
+      .map((x: any) => buildMongoFilter(x, fields, context, prefix))
       .filter((x) => x);
     if (filters.length > 0) {
       switch (filter.logic) {
@@ -559,437 +593,399 @@ const buildMongoFilter = (
               break;
             }
         }
-        switch (filter.operator) {
-          case filterOperator.EQUAL_TO: {
-            // user attributes
-            if (isAttributeFilter) {
-              const attrText = String(attrValue);
-              const numericAttr = Number(attrText);
-              if (attrText === '' || isNaN(numericAttr)) {
-                return { [fieldName]: attrValue };
+        /**
+         * Builds the rule for a given field path, so it can be applied to
+         * both a translation sibling and its source field.
+         *
+         * @param fieldPath path of the field to filter on
+         * @returns Mongo filter for the rule
+         */
+        const buildOperatorFilter = (fieldPath: string): any => {
+          switch (filter.operator) {
+            case filterOperator.EQUAL_TO: {
+              // user attributes
+              if (isAttributeFilter) {
+                const attrText = String(attrValue);
+                const numericAttr = Number(attrText);
+                if (attrText === '' || isNaN(numericAttr)) {
+                  return { [fieldPath]: attrValue };
+                }
+                // Compare both string & number forms, as multiselect fields
+                // can store numeric choice values
+                return {
+                  $or: [
+                    { [fieldPath]: { $eq: attrText } },
+                    { [fieldPath]: { $eq: numericAttr } },
+                  ],
+                };
+              } else if (MULTISELECT_TYPES.includes(type)) {
+                return { [fieldPath]: { $size: value.length, $all: value } };
+              } else if (DATETIME_TYPES.includes(type)) {
+                return {
+                  [fieldPath]: { $gte: startDatetime, $lte: endDatetime },
+                };
+              } else {
+                if (DATE_TYPES.includes(type)) {
+                  return { [fieldPath]: { $gte: value, $lte: endDate } };
+                }
+                if (isNaN(intValue)) {
+                  return { [fieldPath]: { $eq: value } };
+                } else {
+                  return {
+                    $or: [
+                      // Make sure that we compare both strings & numbers
+                      { [fieldPath]: { $eq: String(value) } },
+                      { [fieldPath]: { $eq: intValue } },
+                    ],
+                  };
+                }
               }
-              // Compare both string & number forms, as multiselect fields
-              // can store numeric choice values
+            }
+            case filterOperator.NOT_EQUAL_TO: {
+              // user attributes
+              if (isAttributeFilter) {
+                const attrText = String(attrValue);
+                const numericAttr = Number(attrText);
+                if (attrText === '' || isNaN(numericAttr)) {
+                  return { [fieldPath]: { $ne: attrValue } };
+                }
+                // Compare both string & number forms, as multiselect fields
+                // can store numeric choice values
+                return {
+                  $and: [
+                    { [fieldPath]: { $ne: attrText } },
+                    { [fieldPath]: { $ne: numericAttr } },
+                  ],
+                };
+              } else if (MULTISELECT_TYPES.includes(type)) {
+                return {
+                  [fieldPath]: { $not: { $size: value.length, $all: value } },
+                };
+              } else if (DATETIME_TYPES.includes(type)) {
+                return {
+                  [fieldPath]: {
+                    $not: { $gte: startDatetime, $lte: endDatetime },
+                  },
+                };
+              } else if (DATE_TYPES.includes(type)) {
+                return {
+                  [fieldPath]: { $not: { $gte: value, $lte: endDate } },
+                };
+              } else {
+                if (isNaN(intValue)) {
+                  return { [fieldPath]: { $ne: value } };
+                } else {
+                  return {
+                    $and: [
+                      { [fieldPath]: { $ne: String(value) } },
+                      { [fieldPath]: { $ne: intValue } },
+                    ],
+                  };
+                }
+              }
+            }
+            case filterOperator.IS_NULL: {
               return {
                 $or: [
-                  { [fieldName]: { $eq: attrText } },
-                  { [fieldName]: { $eq: numericAttr } },
+                  { [fieldPath]: { $exists: false } },
+                  { [fieldPath]: { $eq: null } },
                 ],
               };
-            } else if (MULTISELECT_TYPES.includes(type)) {
-              return { [fieldName]: { $size: value.length, $all: value } };
-            } else if (DATETIME_TYPES.includes(type)) {
-              return {
-                [fieldName]: { $gte: startDatetime, $lte: endDatetime },
-              };
-            } else {
+            }
+            case filterOperator.IS_NOT_NULL: {
+              return { [fieldPath]: { $exists: true, $ne: null } };
+            }
+            case filterOperator.LESS_THAN: {
               if (DATE_TYPES.includes(type)) {
-                return { [fieldName]: { $gte: value, $lte: endDate } };
-              }
-              if (isNaN(intValue)) {
-                return { [fieldName]: { $eq: value } };
+                return { [fieldPath]: { $lt: value } };
+              } else if (DATETIME_TYPES.includes(type)) {
+                return { [fieldPath]: { $lt: startDatetime } };
+              } else if (isNaN(intValue)) {
+                return { [fieldPath]: { $lt: value } };
               } else {
                 return {
                   $or: [
-                    // Make sure that we compare both strings & numbers
-                    { [fieldName]: { $eq: String(value) } },
-                    { [fieldName]: { $eq: intValue } },
+                    { [fieldPath]: { $lt: String(value) } },
+                    { [fieldPath]: { $lt: intValue } },
                   ],
                 };
               }
             }
-          }
-          case filterOperator.NOT_EQUAL_TO: {
-            // user attributes
-            if (isAttributeFilter) {
-              const attrText = String(attrValue);
-              const numericAttr = Number(attrText);
-              if (attrText === '' || isNaN(numericAttr)) {
-                return { [fieldName]: { $ne: attrValue } };
-              }
-              // Compare both string & number forms, as multiselect fields
-              // can store numeric choice values
-              return {
-                $and: [
-                  { [fieldName]: { $ne: attrText } },
-                  { [fieldName]: { $ne: numericAttr } },
-                ],
-              };
-            } else if (MULTISELECT_TYPES.includes(type)) {
-              return {
-                [fieldName]: { $not: { $size: value.length, $all: value } },
-              };
-            } else if (DATETIME_TYPES.includes(type)) {
-              return {
-                [fieldName]: {
-                  $not: { $gte: startDatetime, $lte: endDatetime },
-                },
-              };
-            } else if (DATE_TYPES.includes(type)) {
-              return {
-                [fieldName]: { $not: { $gte: value, $lte: endDate } },
-              };
-            } else {
-              if (isNaN(intValue)) {
-                return { [fieldName]: { $ne: value } };
+            case filterOperator.LESS_THAN_OR_EQUAL: {
+              if (DATE_TYPES.includes(type)) {
+                return { [fieldPath]: { $lte: endDate } };
+              } else if (DATETIME_TYPES.includes(type)) {
+                return { [fieldPath]: { $lte: endDatetime } };
+              } else if (isNaN(intValue)) {
+                return { [fieldPath]: { $lte: value } };
               } else {
                 return {
-                  $and: [
-                    { [fieldName]: { $ne: String(value) } },
-                    { [fieldName]: { $ne: intValue } },
+                  $or: [
+                    { [fieldPath]: { $lte: String(value) } },
+                    { [fieldPath]: { $lte: intValue } },
                   ],
                 };
               }
             }
-          }
-          case filterOperator.IS_NULL: {
-            return {
-              $or: [
-                { [fieldName]: { $exists: false } },
-                { [fieldName]: { $eq: null } },
-              ],
-            };
-          }
-          case filterOperator.IS_NOT_NULL: {
-            return { [fieldName]: { $exists: true, $ne: null } };
-          }
-          case filterOperator.LESS_THAN: {
-            if (DATE_TYPES.includes(type)) {
-              return { [fieldName]: { $lt: value } };
-            } else if (DATETIME_TYPES.includes(type)) {
-              return { [fieldName]: { $lt: startDatetime } };
-            } else if (isNaN(intValue)) {
-              return { [fieldName]: { $lt: value } };
-            } else {
-              return {
-                $or: [
-                  { [fieldName]: { $lt: String(value) } },
-                  { [fieldName]: { $lt: intValue } },
-                ],
-              };
-            }
-          }
-          case filterOperator.LESS_THAN_OR_EQUAL: {
-            if (DATE_TYPES.includes(type)) {
-              return { [fieldName]: { $lte: endDate } };
-            } else if (DATETIME_TYPES.includes(type)) {
-              return { [fieldName]: { $lte: endDatetime } };
-            } else if (isNaN(intValue)) {
-              return { [fieldName]: { $lte: value } };
-            } else {
-              return {
-                $or: [
-                  { [fieldName]: { $lte: String(value) } },
-                  { [fieldName]: { $lte: intValue } },
-                ],
-              };
-            }
-          }
-          case filterOperator.GREATER_THAN: {
-            if (DATE_TYPES.includes(type)) {
-              return { [fieldName]: { $gt: endDate } };
-            } else if (DATETIME_TYPES.includes(type)) {
-              return { [fieldName]: { $gt: endDatetime } };
-            } else if (isNaN(intValue)) {
-              return { [fieldName]: { $gt: value } };
-            } else {
-              return {
-                $or: [
-                  { [fieldName]: { $gt: String(value) } },
-                  { [fieldName]: { $gt: intValue } },
-                ],
-              };
-            }
-          }
-          case filterOperator.GREATER_THAN_OR_EQUAL: {
-            if (DATE_TYPES.includes(type)) {
-              return { [fieldName]: { $gte: value } };
-            } else if (DATETIME_TYPES.includes(type)) {
-              return { [fieldName]: { $gte: startDatetime } };
-            } else if (isNaN(intValue)) {
-              return { [fieldName]: { $gte: value } };
-            } else {
-              return {
-                $or: [
-                  { [fieldName]: { $gte: String(value) } },
-                  { [fieldName]: { $gte: intValue } },
-                ],
-              };
-            }
-          }
-          case filterOperator.STARTS_WITH: {
-            return { [fieldName]: { $regex: '^' + value, $options: 'i' } };
-          }
-          case filterOperator.ENDS_WITH: {
-            return { [fieldName]: { $regex: value + '$', $options: 'i' } };
-          }
-          case filterOperator.CONTAINS: {
-            if (filter.field === '_globalSearch') {
-              // Global search: expand into an $or over each per-field rule
-              // produced by the frontend `searchFilters()` helper. Each child
-              // rule is delegated back to buildMongoFilter so all the existing
-              // path-resolution + per-operator logic is reused (default fields
-              // stay flat, others get the `data.` prefix, dotted resource
-              // subfields map to the `_<resource>` lookup alias, multiselect
-              // uses $all, numeric uses $eq, etc.).
-              if (!Array.isArray(value)) {
-                return MATCH_NOTHING;
+            case filterOperator.GREATER_THAN: {
+              if (DATE_TYPES.includes(type)) {
+                return { [fieldPath]: { $gt: endDate } };
+              } else if (DATETIME_TYPES.includes(type)) {
+                return { [fieldPath]: { $gt: endDatetime } };
+              } else if (isNaN(intValue)) {
+                return { [fieldPath]: { $gt: value } };
+              } else {
+                return {
+                  $or: [
+                    { [fieldPath]: { $gt: String(value) } },
+                    { [fieldPath]: { $gt: intValue } },
+                  ],
+                };
               }
-              const subFilters = value
-                .map((rule: any) =>
-                  buildMongoFilter(
-                    {
-                      field: rule.field,
-                      operator: rule.operator,
-                      // Regex operators receive raw user input here; escape it
-                      // so searching e.g. "(test" is treated literally instead
-                      // of breaking the query. Only done for global search, to
-                      // leave explicit column filters untouched.
-                      value:
-                        typeof rule.value === 'string' &&
-                        REGEX_OPERATORS.includes(rule.operator)
-                          ? escapeRegExp(rule.value)
-                          : rule.value,
-                    },
-                    fields,
-                    context,
-                    prefix,
-                    true
-                  )
-                )
-                .filter((x: any) => x && !containsNullComparison(x));
-              if (subFilters.length === 0) {
-                // An active search that cannot match any field must return no
-                // records — dropping the filter would return all of them
-                return MATCH_NOTHING;
+            }
+            case filterOperator.GREATER_THAN_OR_EQUAL: {
+              if (DATE_TYPES.includes(type)) {
+                return { [fieldPath]: { $gte: value } };
+              } else if (DATETIME_TYPES.includes(type)) {
+                return { [fieldPath]: { $gte: startDatetime } };
+              } else if (isNaN(intValue)) {
+                return { [fieldPath]: { $gte: value } };
+              } else {
+                return {
+                  $or: [
+                    { [fieldPath]: { $gte: String(value) } },
+                    { [fieldPath]: { $gte: intValue } },
+                  ],
+                };
               }
-              return { $or: subFilters };
-            } else if (
-              isGlobalSearch &&
-              fallbackFieldName &&
-              typeof value === 'string'
-            ) {
-              // Entity resolvers display the source value when the localized
-              // sibling is missing, null or empty. Apply the regex to that
-              // same per-record value so global search matches what is shown.
-              const translatedValue = `$${fieldName}`;
-              return {
-                $expr: {
-                  $regexMatch: {
-                    input: {
-                      $convert: {
-                        input: {
-                          $cond: [
-                            {
-                              $or: [
-                                {
-                                  $in: [
-                                    { $type: translatedValue },
-                                    ['missing', 'null'],
-                                  ],
-                                },
-                                { $eq: [translatedValue, ''] },
-                              ],
-                            },
-                            `$${fallbackFieldName}`,
-                            translatedValue,
-                          ],
-                        },
-                        to: 'string',
-                        onError: '',
-                        onNull: '',
+            }
+            case filterOperator.STARTS_WITH: {
+              return { [fieldPath]: { $regex: '^' + value, $options: 'i' } };
+            }
+            case filterOperator.ENDS_WITH: {
+              return { [fieldPath]: { $regex: value + '$', $options: 'i' } };
+            }
+            case filterOperator.CONTAINS: {
+              if (filter.field === '_globalSearch') {
+                // Global search: expand into an $or over each per-field rule
+                // produced by the frontend `searchFilters()` helper. Each child
+                // rule is delegated back to buildMongoFilter so all the existing
+                // path-resolution + per-operator logic is reused (default fields
+                // stay flat, others get the `data.` prefix, dotted resource
+                // subfields map to the `_<resource>` lookup alias, multiselect
+                // uses $all, numeric uses $eq, etc.).
+                if (!Array.isArray(value)) {
+                  return MATCH_NOTHING;
+                }
+                const subFilters = value
+                  .map((rule: any) =>
+                    buildMongoFilter(
+                      {
+                        field: rule.field,
+                        operator: rule.operator,
+                        // Regex operators receive raw user input here; escape it
+                        // so searching e.g. "(test" is treated literally instead
+                        // of breaking the query. Only done for global search, to
+                        // leave explicit column filters untouched.
+                        value:
+                          typeof rule.value === 'string' &&
+                          REGEX_OPERATORS.includes(rule.operator)
+                            ? escapeRegExp(rule.value)
+                            : rule.value,
                       },
+                      fields,
+                      context,
+                      prefix
+                    )
+                  )
+                  .filter((x: any) => x && !containsNullComparison(x));
+                if (subFilters.length === 0) {
+                  // An active search that cannot match any field must return no
+                  // records — dropping the filter would return all of them
+                  return MATCH_NOTHING;
+                }
+                return { $or: subFilters };
+              } else if (PEOPLE_TYPES.includes(type)) {
+                // People fields store the person object(s) — search the name /
+                // email subfields the widgets display. Multi-word searches
+                // (e.g. "John Doe") require every word to match one of the
+                // subfields.
+                const tokens = String(value)
+                  .trim()
+                  .split(/\s+/)
+                  .filter(Boolean);
+                if (tokens.length === 0) {
+                  return;
+                }
+                return {
+                  $and: tokens.map((token) => ({
+                    $or: PEOPLE_SEARCH_FIELDS.map((sub) => ({
+                      [`${fieldPath}.${sub}`]: { $regex: token, $options: 'i' },
+                    })),
+                  })),
+                };
+              } else if (type === 'file') {
+                // File fields store an array of file objects; match the file
+                // names, which is what the widgets display
+                return {
+                  [`${fieldPath}.name`]: { $regex: value, $options: 'i' },
+                };
+              } else if (MULTISELECT_TYPES.includes(type)) {
+                return { [fieldPath]: { $all: value } };
+              } else {
+                return { [fieldPath]: { $regex: value, $options: 'i' } };
+              }
+            }
+            case filterOperator.DOES_NOT_CONTAIN: {
+              if (MULTISELECT_TYPES.includes(type)) {
+                return { [fieldPath]: { $not: { $in: value } } };
+              } else {
+                return {
+                  [fieldPath]: { $not: { $regex: value, $options: 'i' } },
+                };
+              }
+            }
+            case filterOperator.IN: {
+              if (isAttributeFilter) {
+                return buildAttributeFieldComparison(fieldPath, attrValue);
+              } else {
+                // Allow values to be passed as string separated with ','
+                if (typeof value === 'string') {
+                  value = value.split(',').map((x) => x.trim());
+                }
+                value = Array.isArray(value) ? value : [value];
+                // Use _id field for objectId filtering
+                if (fieldPath === 'id') {
+                  fieldPath = '_id';
+                }
+                // Try to cast values as object ids if possible
+                try {
+                  return {
+                    $or: [
+                      {
+                        [fieldPath]: {
+                          $in: value.map((x) => new mongoose.Types.ObjectId(x)),
+                        },
+                      },
+                      {
+                        [fieldPath]: {
+                          $in: value,
+                        },
+                      },
+                    ],
+                  };
+                } catch {
+                  return {
+                    [fieldPath]: {
+                      $in: value,
                     },
-                    regex: value,
-                    options: 'i',
-                  },
-                },
-              };
-            } else if (PEOPLE_TYPES.includes(type)) {
-              // People fields store the person object(s) — search the name /
-              // email subfields the widgets display. Multi-word searches
-              // (e.g. "John Doe") require every word to match one of the
-              // subfields.
-              const tokens = String(value).trim().split(/\s+/).filter(Boolean);
-              if (tokens.length === 0) {
+                  };
+                }
+              }
+            }
+            case filterOperator.NOT_IN: {
+              if (isAttributeFilter) {
+                return buildAttributeFieldComparison(
+                  fieldPath,
+                  attrValue,
+                  true
+                );
+              } else {
+                // Allow values to be passed as string separated with ','
+                if (typeof value === 'string') {
+                  value = value.split(',').map((x) => x.trim());
+                }
+                value = Array.isArray(value) ? value : [value];
+                // Use _id field for objectId filtering
+                if (fieldPath === 'id') {
+                  fieldPath = '_id';
+                }
+                // Try to cast values as object ids if possible
+                try {
+                  return {
+                    $and: [
+                      {
+                        [fieldPath]: {
+                          $nin: value.map(
+                            (x) => new mongoose.Types.ObjectId(x)
+                          ),
+                        },
+                      },
+                      {
+                        [fieldPath]: {
+                          $nin: value,
+                        },
+                      },
+                    ],
+                  };
+                } catch {
+                  return {
+                    [fieldPath]: {
+                      $nin: value,
+                    },
+                  };
+                }
+              }
+            }
+            case filterOperator.IS_EMPTY: {
+              if (MULTISELECT_TYPES.includes(type)) {
+                return {
+                  $or: [
+                    { [fieldPath]: { $exists: true, $size: 0 } },
+                    { [fieldPath]: { $exists: false } },
+                    { [fieldPath]: { $eq: null } },
+                  ],
+                };
+              } else {
+                return { [fieldPath]: { $exists: true, $eq: '' } };
+              }
+            }
+            case filterOperator.IS_NOT_EMPTY: {
+              if (MULTISELECT_TYPES.includes(type)) {
+                return { [fieldPath]: { $exists: true, $nin: [null, []] } };
+              } else {
+                return { [fieldPath]: { $exists: true, $nin: [null, ''] } };
+              }
+            }
+            case 'inthelast': {
+              if ([...DATE_TYPES, ...DATETIME_TYPES].includes(type)) {
+                const now = Date.now();
+                const withinTheLastMs = value * 60 * 1000;
+                const dateLowerLimit = new Date(now - withinTheLastMs);
+                return { [fieldPath]: { $gte: dateLowerLimit } };
+              } else {
                 return;
               }
+            }
+            case 'near': {
               return {
-                $and: tokens.map((token) => ({
-                  $or: PEOPLE_SEARCH_FIELDS.map((sub) => ({
-                    [`${fieldName}.${sub}`]: { $regex: token, $options: 'i' },
-                  })),
-                })),
-              };
-            } else if (type === 'file') {
-              // File fields store an array of file objects; match the file
-              // names, which is what the widgets display
-              return {
-                [`${fieldName}.name`]: { $regex: value, $options: 'i' },
-              };
-            } else if (MULTISELECT_TYPES.includes(type)) {
-              return { [fieldName]: { $all: value } };
-            } else {
-              return { [fieldName]: { $regex: value, $options: 'i' } };
-            }
-          }
-          case filterOperator.DOES_NOT_CONTAIN: {
-            if (MULTISELECT_TYPES.includes(type)) {
-              return { [fieldName]: { $not: { $in: value } } };
-            } else {
-              return {
-                [fieldName]: { $not: { $regex: value, $options: 'i' } },
-              };
-            }
-          }
-          case filterOperator.IN: {
-            if (isAttributeFilter) {
-              return buildAttributeFieldComparison(fieldName, attrValue);
-            } else {
-              // Allow values to be passed as string separated with ','
-              if (typeof value === 'string') {
-                value = value.split(',').map((x) => x.trim());
-              }
-              value = Array.isArray(value) ? value : [value];
-              // Use _id field for objectId filtering
-              if (fieldName === 'id') {
-                fieldName = '_id';
-              }
-              // Try to cast values as object ids if possible
-              try {
-                return {
-                  $or: [
-                    {
-                      [fieldName]: {
-                        $in: value.map((x) => new mongoose.Types.ObjectId(x)),
-                      },
+                [fieldPath]: {
+                  $near: {
+                    $geometry: {
+                      type: 'Point',
+                      coordinates: value.geometry,
                     },
-                    {
-                      [fieldName]: {
-                        $in: value,
-                      },
-                    },
-                  ],
-                };
-              } catch {
-                return {
-                  [fieldName]: {
-                    $in: value,
-                  },
-                };
-              }
-            }
-          }
-          case filterOperator.NOT_IN: {
-            if (isAttributeFilter) {
-              return buildAttributeFieldComparison(fieldName, attrValue, true);
-            } else {
-              // Allow values to be passed as string separated with ','
-              if (typeof value === 'string') {
-                value = value.split(',').map((x) => x.trim());
-              }
-              value = Array.isArray(value) ? value : [value];
-              // Use _id field for objectId filtering
-              if (fieldName === 'id') {
-                fieldName = '_id';
-              }
-              // Try to cast values as object ids if possible
-              try {
-                return {
-                  $and: [
-                    {
-                      [fieldName]: {
-                        $nin: value.map((x) => new mongoose.Types.ObjectId(x)),
-                      },
-                    },
-                    {
-                      [fieldName]: {
-                        $nin: value,
-                      },
-                    },
-                  ],
-                };
-              } catch {
-                return {
-                  [fieldName]: {
-                    $nin: value,
-                  },
-                };
-              }
-            }
-          }
-          case filterOperator.IS_EMPTY: {
-            if (MULTISELECT_TYPES.includes(type)) {
-              return {
-                $or: [
-                  { [fieldName]: { $exists: true, $size: 0 } },
-                  { [fieldName]: { $exists: false } },
-                  { [fieldName]: { $eq: null } },
-                ],
-              };
-            } else {
-              return { [fieldName]: { $exists: true, $eq: '' } };
-            }
-          }
-          case filterOperator.IS_NOT_EMPTY: {
-            if (MULTISELECT_TYPES.includes(type)) {
-              return { [fieldName]: { $exists: true, $nin: [null, []] } };
-            } else {
-              return { [fieldName]: { $exists: true, $nin: [null, ''] } };
-            }
-          }
-          case 'inthelast': {
-            if ([...DATE_TYPES, ...DATETIME_TYPES].includes(type)) {
-              const now = Date.now();
-              const withinTheLastMs = value * 60 * 1000;
-              const dateLowerLimit = new Date(now - withinTheLastMs);
-              return { [fieldName]: { $gte: dateLowerLimit } };
-            } else {
-              return;
-            }
-          }
-          case 'near': {
-            return {
-              [fieldName]: {
-                $near: {
-                  $geometry: {
-                    type: 'Point',
-                    coordinates: value.geometry,
-                  },
-                  $maxDistance: value.distance,
-                },
-              },
-            };
-          }
-          case 'notnear': {
-            return {
-              [fieldName]: {
-                $near: {
-                  $geometry: {
-                    type: 'Point',
-                    coordinates: value.geometry,
-                  },
-                  $minDistance: value.distance,
-                },
-              },
-            };
-          }
-          case 'intersects': {
-            return {
-              [fieldName]: {
-                $geoIntersects: {
-                  $geometry: {
-                    type: 'Polygon',
-                    coordinates: value.geometry,
+                    $maxDistance: value.distance,
                   },
                 },
-              },
-            };
-          }
-          case 'notintersects': {
-            return {
-              [fieldName]: {
-                $not: {
+              };
+            }
+            case 'notnear': {
+              return {
+                [fieldPath]: {
+                  $near: {
+                    $geometry: {
+                      type: 'Point',
+                      coordinates: value.geometry,
+                    },
+                    $minDistance: value.distance,
+                  },
+                },
+              };
+            }
+            case 'intersects': {
+              return {
+                [fieldPath]: {
                   $geoIntersects: {
                     $geometry: {
                       type: 'Polygon',
@@ -997,13 +993,37 @@ const buildMongoFilter = (
                     },
                   },
                 },
-              },
-            };
+              };
+            }
+            case 'notintersects': {
+              return {
+                [fieldPath]: {
+                  $not: {
+                    $geoIntersects: {
+                      $geometry: {
+                        type: 'Polygon',
+                        coordinates: value.geometry,
+                      },
+                    },
+                  },
+                },
+              };
+            }
+            default: {
+              return;
+            }
           }
-          default: {
-            return;
-          }
+        };
+        // Translated text fields: match the displayed value, i.e. the
+        // translation sibling when set, otherwise the source field
+        if (fallbackFieldName) {
+          return withTranslationFallback(
+            fieldName,
+            fallbackFieldName,
+            buildOperatorFilter
+          );
         }
+        return buildOperatorFilter(fieldName);
       } else {
         return;
       }

--- a/src/utils/schema/resolvers/Query/getSortAggregation.ts
+++ b/src/utils/schema/resolvers/Query/getSortAggregation.ts
@@ -8,6 +8,56 @@ import { resolveLocalizedString } from '@utils/i18n/resolveLocalizedString';
 import { SortDescriptor } from './normalizeSortDescriptors';
 
 /**
+ * Resolves the translation sibling of a sort field for the user's locale.
+ *
+ * Top-level fields carry their siblings in the structure fields; subfields of
+ * a related resource (`<resource>.<subfield>`) carry them on the related
+ * resource's own fields, exposed through `context.resourceFieldsById`.
+ *
+ * @param sortField Sort by field
+ * @param fields Structure fields
+ * @param context Request context
+ * @returns Translated field name, plus the document paths of the translation and of its source when a sibling exists
+ */
+const resolveTranslation = (
+  sortField: string,
+  fields: any[],
+  context: any
+): { name: string; translatedPath?: string; sourcePath?: string } => {
+  const locale = context?.locale;
+  if (sortField && sortField.includes('.')) {
+    const [resourceName, subField] = sortField.split('.');
+    const resourceField = fields.find(
+      (x) => x && x.name === resourceName && x.type === 'resource'
+    );
+    const relatedFields =
+      context?.resourceFieldsById?.[resourceField?.resource] || [];
+    const translatedSubField = getTranslatedFieldName(
+      subField,
+      relatedFields,
+      locale
+    );
+    if (translatedSubField === subField) {
+      return { name: sortField };
+    }
+    return {
+      name: `${resourceName}.${translatedSubField}`,
+      translatedPath: `_${resourceName}.data.${translatedSubField}`,
+      sourcePath: `_${resourceName}.data.${subField}`,
+    };
+  }
+  const translated = getTranslatedFieldName(sortField, fields, locale);
+  if (translated === sortField) {
+    return { name: sortField };
+  }
+  return {
+    name: translated,
+    translatedPath: `data.${translated}`,
+    sourcePath: `data.${sortField}`,
+  };
+};
+
+/**
  * Builds the aggregation stages (choice-resolution + sort) for a single sort
  * descriptor, and adds its resolved path/order to the shared sort stage.
  *
@@ -27,19 +77,46 @@ const buildSortDescriptorAggregation = async (
 ): Promise<any[]> => {
   // Locale-based translation: replace the sort field with its sibling
   // translation field when one matches the user's locale.
-  sortField = getTranslatedFieldName(sortField, fields, context?.locale);
+  const translation = resolveTranslation(sortField, fields, context);
+  sortField = translation.name;
 
   const field: any = fields.find((x) => x && x.name === sortField);
+  const hasChoices =
+    field && (field.choices || field.choicesByUrl || field.choicesByGraphQL);
+
+  // Translated text fields: sort on the displayed value, i.e. the translation
+  // sibling when set, otherwise the source field (same fallback as the entity
+  // resolvers and as getFilter)
+  if (translation.translatedPath && !hasChoices) {
+    const alias = `_${sortField.replace('.', '_')}`;
+    const translatedValue = `$${translation.translatedPath}`;
+    sortStage[alias] = getSortOrder(sortOrder);
+    return [
+      {
+        $addFields: {
+          [alias]: {
+            $cond: [
+              {
+                $or: [
+                  { $in: [{ $type: translatedValue }, ['missing', 'null']] },
+                  { $eq: [translatedValue, ''] },
+                ],
+              },
+              `$${translation.sourcePath}`,
+              translatedValue,
+            ],
+          },
+        },
+      },
+    ];
+  }
   const parentField: any =
     sortField && sortField.includes('.')
       ? fields.find((x) => x && x.name === sortField.split('.')[0])
       : '';
   const aggregation = [];
   // If we need to populate choices to sort on the text value
-  if (
-    field &&
-    (field.choices || field.choicesByUrl || field.choicesByGraphQL)
-  ) {
+  if (hasChoices) {
     const rawChoices = (await getFullChoices(field, context)) || [];
     // Resolve each choice's (possibly localized) text to the active locale so
     // that we sort on the displayed value rather than the raw locale object.


### PR DESCRIPTION
# Description

Global search wasn’t finding records when a translated field was empty, even though the UI displayed the original value as a fallback. Search now follows the same logic as the UI: it uses the original value when the translation is missing or empty, and the translated value when available. This also works for fields from linked resources and only affects global search, not regular column filters.

## Useful links

- https://dev.azure.com/WHOHQ/EMSSAFE/_workitems/edit/137461/

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The backend filter unit tests were extended to cover translated-field fallback behavior for direct and linked-resource fields. Regression coverage verifies that regular column filters retain their previous behavior.

- npm run test -- --runInBand __tests__/unit-tests/utils/schema/resolvers/Query/getFilter.spec.ts - 32 tests passed
- npm run lint and npm run build completed successfully

## Screenshots

<img width="1600" height="371" alt="image" src="https://github.com/user-attachments/assets/804153a6-2bd6-460e-a5f2-79a9e23c2acc" />

# Checklist:

( * == Mandatory ) 

- [X] * I have set myself as assignee of the pull request
- [X] * My code follows the style guidelines of this project
- [X] * Linting does not generate new warnings
- [X] * I have performed a self-review of my own code
- [X] * I have put the ticket for review, adding the oort-backend team to the list of reviewers
- [X] * I have commented my code, particularly in hard-to-understand areas
- [X] * I have put JSDoc comment in all required places
- [X] * My changes generate no new warnings
- [X] * I have included screenshots describing my changes if relevant
- [X] * I have selected labels in the Pull Request, according to the changes with code brings
- [ ] I have made corresponding changes to the documentation ( if required )
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules